### PR TITLE
Warning management

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -136,3 +136,5 @@ html_sidebars = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 html_css_files = ['css/custom.css']
+
+suppress_warnings = ['autosectionlabel.*']

--- a/source/index.rst
+++ b/source/index.rst
@@ -53,3 +53,21 @@ Quick Links
     Workshop Website Template <https://github.com/carpentries/workshop-template>
 
 
+.. toctree::
+    :hidden:
+
+    workshops/instructors
+    pages/sample
+    instructor_training/trainers 
+    pages/style_guide
+    pages/resources
+    pages/onboarding_offboarding
+    pages/learn_how
+    pages/connect
+    pages/coc
+    instructor_training/trainers_leadership
+    curriculum/maintainers
+    curriculum/lesson_developers
+    curriculum/curriculum_advisors
+    community/discussion_host
+    community/carpentrycon


### PR DESCRIPTION
This PR does the following:

* Adds `suppress_warnings = ['autosectionlabel.*']` to `conf.py` so that warnings about duplicate headings across documents are suppressed
* Adds a hidden TOC to `index.py` so that warnings about docs not in any toctree are suppressed. 

This allows warnings that we really do need to see become more visible.