### PR TITLE
variables in conf.py

### DIFF
--- a/source/community/carpentrycon.rst
+++ b/source/community/carpentrycon.rst
@@ -2043,8 +2043,7 @@ script used
 to analyse the 2022 Post Conference Survey and produce the figures for
 the 2022 CarpentryCon Evaluation Report. <https://github.com/carpentries/assessment/blob/main/carpentrycon/2022/carpentrycon_survey_analysis_template.R>`__
 
-`R script for analyzing post conference survey
-   data <https://github.com/carpentries/assessment/blob/main/carpentrycon/2022/carpentrycon_survey_analysis_template.R>`__
+`R script for analyzing post conference survey data <https://github.com/carpentries/assessment/blob/main/carpentrycon/2022/carpentrycon_survey_analysis_template.R>`__
 
 Committee Member Feedback Form
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/community/discussion_host.rst
+++ b/source/community/discussion_host.rst
@@ -62,12 +62,13 @@ responsibilities include:
    questions answered. On the sign up list, these people will have
    included the word checkout next to their name.
 -  Complete `a brief form <https://forms.gle/N74pFuGkRLawpCHh7>`__
-   following each session you host. **It is important that when you copy
+   following each session you host. It is important that when you copy
    attendance into this form, you include the word ‘checkout’ next to
    the names where it appears in the sign-up on the Etherpad. The Core
-   Team uses this information to record participation in AMY, The
+   Team uses this information to record participation in  `AMY
+   <amy_link_>`_, The
    Carpentries internal database. This is the primary way future
-   Instructors get credit for completing this checkout step.**
+   Instructors get credit for completing this checkout step.
 
 Onboarding
 ----------

--- a/source/conf.py
+++ b/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'myst_parser',
     'sphinx.ext.autosectionlabel',
     'sphinx_panels',
+    'sphinx.ext.extlinks'
 ]
 
 # Needed to use headings as anchor links
@@ -139,3 +140,42 @@ html_static_path = ['_static']
 html_css_files = ['css/custom.css']
 
 suppress_warnings = ['autosectionlabel.*']
+
+
+# rst_prolog = """
+# .. |psf| replace:: Python Software Foundation
+# .. |amy_link| replace:: https://amy.carpentries.org/ 
+# """
+
+
+# These links can be used anywhere in this documentation.  
+# Sample syntax in the rst file: 
+# Log in to `your amy profile <amy_link_>`_ to view your profile.
+
+rst_prolog = """
+"""
+
+# AMY Links 
+rst_prolog += """
+.. _amy_link: https://amy.carpentries.org
+.. _amy_workshop_request: https://amy.carpentries.org/forms/workshop/
+.. _amy_training_application: https://amy.carpentries.org/forms/request_training/
+"""
+
+# Other Carpentries websites 
+rst_prolog += """
+.. _main_carpentries_site: https://carpentries.org 
+.. _datacarpentry_site: https://datacarpentry.org
+.. _librarycarpentry_site: https://librarycarpentry.org
+.. _softwarecarpentry_site: https://software-carpentry.org/
+"""
+
+# Note that extlinks must be added to extensions above.
+# Sample syntax in the rst file:
+# Complete the :amy_url:`workshop request form <forms/workshop/>`.
+# or
+# Log in to :amy_url:`your profile <>` in AMY.
+
+extlinks = {
+    'amy_url' : ('https://amy.carpentries.org/%s', None)
+}

--- a/source/curriculum/curriculum_advisors.rst
+++ b/source/curriculum/curriculum_advisors.rst
@@ -112,7 +112,7 @@ Onboarding
 -  After these onboarding sessions, Curriculum Advisors should complete
    the following steps:
 
-   1. `Log into AMY <https://amy.carpentries.org/>`__ with GitHub
+   1. `Log into AMY <amy_link_>`_ with GitHub
       credentials and update their profile.
 
       -  When updating their AMY profile, it is essential that Advisors

--- a/source/curriculum/lesson_developers.rst
+++ b/source/curriculum/lesson_developers.rst
@@ -455,7 +455,7 @@ developed based on prior agreement with The Carpentries, and which is
 intended to become another lesson/curriculum offered in
 centrally-organised workshops - please `register your pilot as a
 Self-Organised
-Workshop <https://amy.carpentries.org/forms/self-organised/>`__. If you
+Workshop <amy_workshop_request_>`_. If you
 do not find the lesson/curriculum being piloted listed as one of the
 choices on that form, please contact `The Carpentries Core
 Team <mailto:team@carpentries.org>`__.

--- a/source/instructor_training/trainers.rst
+++ b/source/instructor_training/trainers.rst
@@ -478,7 +478,7 @@ Carpentries infrastructure. This includes:
 
 -  **Eventbrite registration**, using our event template. This template
    includes a prompt for trainees to fill out the Profile Creation Form
-   in AMY, an essential step to tracking their progress through
+   in `AMY <amy_link_>`_ , an essential step to tracking their progress through
    checkout. Trainers will have access to registration data and can make
    changes to the Eventbrite page as needed.
 -  **Carpentries Zoom** room to use for virtual events

--- a/source/workshops/instructors.rst
+++ b/source/workshops/instructors.rst
@@ -390,7 +390,7 @@ Pre-workshop
    -  There are 3 things that must happen in order for a workshop to
       appear on The Carpentries webpage. You must complete the `workshop
       request/notification
-      form <https://amy.carpentries.org/forms/workshop/>`__, the
+      form <amy_workshop_request_>`__, the
       workshop website must include the venue, and at least one
       instructor must be identified. If the instructors change, we will
       get notified and will be able to make the update.
@@ -492,8 +492,8 @@ Curriculum
       the workshop does not align with the `Core
       Curriculum <https://carpentries.org/workshops/#workshop-core>`__
       we ask that you still
-      `register <https://amy.carpentries.org/forms/self-organised/>`__
-      your workshop and select the “Mix & Match” option for the question
+      `register <amy_workshop_request_>`__
+      your self-organised workshop and select the “Mix & Match” option for the question
       “Which Carpentries workshop are you teaching?”. **This option is
       only available for Self-Organised workshops. Centrally-organised
       workshops are required to follow the Core Curricula.**

--- a/source/workshops/instructors.rst
+++ b/source/workshops/instructors.rst
@@ -66,7 +66,7 @@ Upcoming Workshops
 
 If you are an Active Instructor and would like to see a list of teaching
 opportunities that need Instructors, please go to your `AMY
-profile <https://amy.carpentries.org/>`__ to see a list of upcoming
+profile <amy_link_>`_ to see a list of upcoming
 workshops that you can sign up to teach.
 
 Community Calendar


### PR DESCRIPTION
Sets up conf.py to use variables for links to be used across the handbooks.  Begins with links to AMY. 