### PR TITLE
Updates "about" section of each community role handbook

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -192,7 +192,7 @@ myst_substitutions = {
   "workshops_email": "workshops@carpentries.org",
   "membership_email": "membership@carpentries.org",
   "community_email": "community@carpentries.org",
-  "curriculum _email": "curriculum@carpentries.org",
+  "curriculum_email": "curriculum@carpentries.org",
   "gh_repo": "https://github.com/carpentries/handbook-beta",
 
   

--- a/source/conf.py
+++ b/source/conf.py
@@ -191,6 +191,8 @@ myst_substitutions = {
   "instructor_training_email": "instructor.training@carpentries.org",
   "workshops_email": "workshops@carpentries.org",
   "membership_email": "membership@carpentries.org",
+  "community_email": "community@carpentries.org",
+  "curriculum _email": "curriculum@carpentries.org",
 
   
 }

--- a/source/conf.py
+++ b/source/conf.py
@@ -193,6 +193,7 @@ myst_substitutions = {
   "membership_email": "membership@carpentries.org",
   "community_email": "community@carpentries.org",
   "curriculum _email": "curriculum@carpentries.org",
+  "gh_repo": "https://github.com/carpentries/handbook-beta",
 
   
 }

--- a/source/handbooks/community_session_host.md
+++ b/source/handbooks/community_session_host.md
@@ -1,5 +1,12 @@
 # Community Session Hosts Handbook
 
+## About This Handbook
+
+The Community Discussion Host Handbook is designed to support members of The
+Carpentries community who are serving as a Community Discussion Host. It is maintained by The Carpentries Community Engagement Team.  If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please email the {{'[Community Engagement Team](mailto:{})'.format(community_email)}} or open an issue on the {{'[source repository of this handbook]({})'.format(gh_repo)}}. If you are unfamiliar with any of the terms used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.
+
+## Introduction
+
 Hosting a community discussion is a great way to meet more people in The
 Carpentries community, get to know the organisation better, learn from
 the experiences of others and share your own knowledge and experience
@@ -579,13 +586,3 @@ formalized through the Community Development Program. If you are
 interested in learning more, please email community@carpentries.org.
 
 
-## About This Handbook
-
-The Community Discussion Host Handbook is a resource for members of The
-Carpentries community who are serving as a Community Discussion Host.
-This handbook provides information on how to receive relevant
-communications and includes step-by-step guides for serving in this
-role. The Carpentries Community Development Team manages the content of
-this handbook. To provide feedback, please email
-community@carpentries.org. If you are unfamiliar with any of the terms
-used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.

--- a/source/handbooks/curriculum_advisors.md
+++ b/source/handbooks/curriculum_advisors.md
@@ -1,5 +1,13 @@
 # Curriculum Advisors Handbook
 
+## About This Handbook
+
+The Curriculum Advisor Handbook is designed to support members of The
+Carpentries community who are serving on a Curriculum Advisory
+Committee. It is maintained by The Carpentries Curriculum Team.  If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please email the {{'[Curriculum Team](mailto:{})'.format(curriculum_email)}} or open an issue on the {{'[source repository of this handbook]({})'.format(gh_repo)}}. If you are unfamiliar with any of the terms used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.
+
+## Introduction 
+
 Curriculum Advisors are part of a team that provides the oversight,
 vision, and leadership for a particular set of lessons. Curriculum
 Advisors represent The Carpentries community and should strive to embody
@@ -494,15 +502,3 @@ Maintainers?**
 Please review the [Curriculum Advisory Committee Consultation
 Rubric](https://docs.carpentries.org/topic_folders/lesson_development/cac-consult-rubric.html).
 
-## About This Handbook
-
-
-The Curriculum Advisor Handbook is a resource for members of The
-Carpentries community who are serving on a Curriculum Advisory
-Committee. This handbook will provide you with information on how to
-receive relevant communications and includes a step-by-step guide for
-serving in this role. The Carpentries Curriculum Team manages the
-content of this handbook. To provide feedback, please email the
-[Curriculum Team](mailto:team@carpentries.org). If you are unfamiliar
-with any of the terms used in this handbook, please refer to our
-Glossary of Terms.

--- a/source/handbooks/instructor_trainers.md
+++ b/source/handbooks/instructor_trainers.md
@@ -1,5 +1,13 @@
 # Instructor Trainers Handbook
 
+## About This Handbook
+
+The Instructor Trainers Handbook is designed to support members of The
+Carpentries community who are serving as an Instructor Trainer. It is maintained by The Carpentries Workshops and Instruction Team.  If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please email the {{'[Workshops and Instruction Team](mailto:{})'.format(instructor_training_email)}} or open an issue on the {{'[source repository of this handbook]({})'.format(gh_repo)}}. If you are unfamiliar with any of the terms used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.
+
+
+## Introduction 
+
 Instructor Trainers (‘Trainers’) are certified to co-teach Carpentries
 Instructor Training events, the first step in certification for
 Carpentries Instructors. Trainers also support 
@@ -908,10 +916,6 @@ Sincerely,
 Check your Calendly confirmation email for the Host Key. This key is
 also available in a message in the [Trainers Topicbox channel](https://carpentries.topicbox.com/groups/trainers/T3ec157cc9a3d1833/zoom-host-code). If you have difficulty, you can post in the #trainers channel on Slack.
 
-## About This Handbook
 
-Please include the following information:
 
--  What is the handbook for? Why does it exist?
--  Who is responsible for updating its content?
--  How can someone provide feedback on its content?
+

--- a/source/handbooks/instructors.md
+++ b/source/handbooks/instructors.md
@@ -1,5 +1,12 @@
 # Instructors Handbook
 
+## About This Handbook
+
+The Instructor Handbook is designed to support members of The
+Carpentries community who are serving as an Instructor. It is maintained by The Carpentries Workshops and Instruction Team.  If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please email the {{'[Workshops and Instruction Team](mailto:{})'.format(workshops_email)}} or open an issue on the {{'[source repository of this handbook]({})'.format(gh_repo)}}. If you are unfamiliar with any of the terms used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.
+
+## Introduction
+
 Carpentries Instructors are volunteers who are certified through the
 Carpentries Instructor Training program to teach live-coding and data
 skills to learners through evidence based-teaching practices.
@@ -551,14 +558,4 @@ content in the handbook.
         please do let us know as we will not be able to pull information
         from your website without updating the link in our database.
 
-## About This Handbook
 
-
--   What is the handbook for? Why does it exist?
-    -   To provide understanding of a Carpentries workshop and how they
-        are organised and managed
--   Who is responsible for updating its content?
-    -   The Workshops and Instruction Team
--   How can someone provide feedback on its content?
-    -   Email the [Workhops and Instruction
-        Team](mailto:workshops@carpentries.org)

--- a/source/handbooks/lesson_developers.md
+++ b/source/handbooks/lesson_developers.md
@@ -489,23 +489,5 @@ to publicise the beta version of a lesson. These can be used to call for
 community members to volunteer to host a beta pilot workshop to aid the
 ongoing development of the lesson.
 
-## FAQ
-
-**Question 1**
-
-Response 1
-
-**Question 2**
-
-Response 2
 
 
-## About This Handbook
-
-This handbook is designed to support members of The Carpentries
-community who are developing new lessons in The Carpentries Incubator.
-It is maintained by The Carpentries Curriculum Team. If you believe
-anything needs to be added or updated here, or if you would like to
-provide feedback on the content, please email the [Curriculum
-Team](mailto:curriculum@carpentries.org), or open an issue on the
-[source repository of this handbook](https://github.com).

--- a/source/handbooks/lesson_developers.md
+++ b/source/handbooks/lesson_developers.md
@@ -1,12 +1,11 @@
 # Lesson Developers Handbook
 
-Lesson Developers create new lessons using The Carpentries open source
-lesson infrastructure. This lesson development takes place in The
-Carpentries Incubator, a space for the community to collaborate on
-lesson projects.
+## About This Handbook 
+
+The Lesson Developers Handbook is designed to support members of The
+Carpentries community who are serving as a Lesson Developer. It is maintained by The Carpentries Curriculum Team.  If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please email the {{'[Curriculum Team](mailto:{})'.format(curriculum_email)}} or open an issue on the {{'[source repository of this handbook]({})'.format(gh_repo)}}. If you are unfamiliar with any of the terms used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.
 
 ## Roles and Responsibilities
-
 
 Beyond ensuring that the lesson remains compliant with the requirements
 for inclusion in [The Carpentries

--- a/source/handbooks/lesson_program_governors.md
+++ b/source/handbooks/lesson_program_governors.md
@@ -1,5 +1,12 @@
 # Lesson Program Governor Handbook
 
+## About This Handbook 
+
+The Lesson Program Governor Handbook is designed to support members of The
+Carpentries community who are serving as a Lesson Program Governor. It is maintained by The Carpentries Curriculum Team.  If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please email the {{'[Curriculum Team](mailto:{})'.format(curriculum_email)}} or open an issue on the {{'[source repository of this handbook]({})'.format(gh_repo)}}. If you are unfamiliar with any of the terms used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.
+
+## Introduction 
+
 Lesson Program Governors are members of **Lesson Program Governance Committees (LPGCs)**, groups of community members that oversee and guide the strategy and health of The Carpentries Lesson Programs.
 
 The responsibilities of Lesson Program Governance Committees fall into three main categories of leadership: strategy, advocacy, and communication.
@@ -145,5 +152,3 @@ Official policy from The Carpentries Executive Council describing how individual
 #### About this resource
 The Carpentries general policy for committees is provided by the Executive Council. This policy describes in general terms the responsibilities and requirements of an official committee such as an LPGC within the organisation.
 
-## About This Section
-This section of the handbook is designed to support members of Lesson Program Governance Committees within The Carpentries community. It is maintained by The Carpentries Curriculum Team. If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please send a message to the team at <curriculum@carpentries.org>, or open an issue on [the source repository of this handbook](https://github.com/carpentries/docs.carpentries.org).

--- a/source/handbooks/maintainers.md
+++ b/source/handbooks/maintainers.md
@@ -1,5 +1,12 @@
 # Maintainers Handbook
 
+## About This Handbook 
+
+The Maintainers Handbook is designed to support members of The
+Carpentries community who are serving as a Lesson Maintainer. It is maintained by The Carpentries Curriculum Team.  If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please email the {{'[Curriculum Team](mailto:{})'.format(curriculum_email)}} or open an issue on the {{'[source repository of this handbook]({})'.format(gh_repo)}}. If you are unfamiliar with any of the terms used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.
+
+## Introduction
+
 The Carpentries Maintainers work with the community to ensure
 lessons stay up-to-date, accurate, functional and cohesive. Maintainers
 monitor their lesson repository, ensure that pull requests and issues
@@ -321,26 +328,5 @@ lesson website development, and collaboration via GitHub. Community
 members can apply to join this training, and/or follow the curriculum in
 their own time.
 
-## FAQ
 
-List of frequently asked questions relevant to the content in the
-handbook.
 
-**Question 1**
-
-Response 1
-
-**Question 2**
-
-Response 2
-
-## About This Handbook
-
-This handbook is designed to support Maintainers - members of The
-Carpentries community who maintain one or more lesson repositories for
-our lesson programs. It is maintained by The Carpentries Curriculum
-Team. If you believe anything needs to be added or updated here, or if
-you would like to provide feedback on the content, please send an
-message to the [Curriculum Team](mailto:curriculum@carpentries.org)
-or open an issue on [the source repository of this
-handbook](https://github.com/carpentries/handbook-beta).


### PR DESCRIPTION
Addresses #95.
Updates the "about" section of each community role handbook to be at the top of the page and have the same information in paragraph form.