### PR TITLE
replace instructor trainer handbook with google doc content

### DIFF
--- a/source/handbooks/instructor_trainers.md
+++ b/source/handbooks/instructor_trainers.md
@@ -1,699 +1,319 @@
 # Instructor Trainers Handbook
 
-## About This Handbook
+## About This Handbook 
 
 The Instructor Trainers Handbook is designed to support members of The
-Carpentries community who are serving as an Instructor Trainer. It is maintained by The Carpentries Workshops and Instruction Team.  If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please email the {{'[Workshops and Instruction Team](mailto:{})'.format(instructor_training_email)}} or open an issue on the {{'[source repository of this handbook]({})'.format(gh_repo)}}. If you are unfamiliar with any of the terms used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.
+Carpentries community who are serving as a Instructor Trainer. It is maintained by The Carpentries Workshops and Instruction Team.  If you believe anything needs to be added or updated here, or if you would like to provide feedback on the content, please email the {{'[Workshops and Instruction Team](mailto:{})'.format(workshops_email)}} or open an issue on the {{'[source repository of this handbook]({})'.format(gh_repo)}}. If you are unfamiliar with any of the terms used in this handbook, please refer to our {{'[Glossary of terms]({})'.format(glossary)}}.
 
+## Introduction
 
-## Introduction 
+Instructor Trainers are certified to co-teach Carpentries Instructor Training events, the first step in certification for Carpentries Instructors. Instructor Trainers also support [Instructor certification](https://carpentries.github.io/instructor-training/14-checkout.html), also known as Checkout, evaluating trainees’ teaching demonstrations. 
 
-Instructor Trainers (‘Trainers’) are certified to co-teach Carpentries
-Instructor Training events, the first step in certification for
-Carpentries Instructors. Trainers also support 
-{{'[Instructor certification]({}/checkout)'.format(instructor_training_curriculum)}},
-also known as Checkout, evaluating trainees’ teaching demonstrations.
+The Instructor Trainer community plays a leading role in The Carpentries, maintaining our flagship [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/), supporting policy development around training, and bringing Carpentries instructional practices to leadership roles across our local and global communities.
 
-The Trainer community plays a leading role in The Carpentries, maintaining our flagship {{'[Instructor Training Curriculum]({})'.format(instructor_training_curriculum)}}, supporting policy development around training, and bringing Carpentries instructional practices to leadership roles across our local and global communities.
+Instructor Trainers join a global community of skilled professionals with a passion for evidence-based teaching and a shared goal of expanding access to instructional training. Instructor Trainers build their knowledge and skills through co-instruction and monthly discussions, with additional opportunities for in-depth exploration of relevant topics throughout the year. 
 
-Trainers join a global community of skilled professionals with a passion
-for evidence-based teaching and a shared goal of expanding access to
-instructional training. Trainers build their own knowledge and skill
-through co-instruction and monthly discussions, with additional
-opportunities for in-depth exploration of relevant topics throughout the
-year.
-
-Trainers can assume leadership roles within the Trainer community, as
-Instructor Training Curriculum Maintainers, or members of the Trainers
-Leadership Committee.
-
-Trainers often engage in leadership roles in their home communities,
-mentoring local Instructors and modelling best practices. In most cases
-Trainers do not self-organise private Instructor Training events for a
-single local community, but these are allowed in certain circumstances.
-More information on [Self-Organise a Private Instructor Training
-Event](#self-organise-a-private-instructor-training-event).
+Instructor Trainers often engage in leadership roles in their home communities, mentoring local Instructors and modelling best practices. Instructor Trainers can assume leadership roles within the Instructor Trainer community as Instructor Training Curriculum Maintainers or members of the Instructor Trainers Leadership Committee.
 
 ## Roles and Responsibilities
 
-Trainers teach Instructor Training events, host teaching demonstrations,
-and attend Trainer community meetings. In order to remain active, we ask
-that Trainers annually:
+Instructor Trainers teach Instructor Training events, host teaching demonstrations, and attend Instructor Trainer community meetings. To remain active, we ask that Instructor Trainers annually: 
 
--  teach 1 Instructor Training event, and
--  host 2 teaching demos, and
--  attend 4 Trainer community meetings
+* teach 1 Instructor Training event, and  
+* host 2 teaching demos, and  
+* attend 4 Instructor Trainer community meetings
 
 OR
 
--  equivalent engagement with curriculum, trainees, or the Trainer
-   community, as approved by the Trainers Leadership
+* equivalent engagement with curriculum, trainees, or the Instructor Trainer community, as approved by the Instructor Trainers Leadership
 
-The estimated time investment for these activities is 25-30 hours per
-year, depending on preparation needs.
+The estimated time investment for these activities is 25-30 hours per year, depending on preparation needs.
 
-Trainers whose service is included in a member agreement may have
-additional requirements – please refer to your member agreement for
-details.
+Instructor Trainers whose service is included in a member agreement may have additional requirements – please refer to your member agreement for details.
 
 ## Onboarding
 
-### Trainer Training Program
+### Instructor Trainer Training Program
 
 #### Admission
 
-The Trainer community periodically accepts new members via application.
+The Instructor Trainer community periodically accepts new members via application. 
 
--  Trainer Training is a **10-week program that is held 1-2 times per
-   year** as needed.
--  All Trainer **candidates must apply and be approved** by a panel of
-   current Instructor Trainers. We strongly recommend that candidates
-   have either had
-
-   -  **prior experience teaching Carpentries workshops** (with existing
-      Instructor certification) or
-   -  **significant prior training in teaching** (e.g. courses or a
-      degree in education; experience teaching is also useful but is not
-      the same as training)
-
--  Trainer Training seats are offered to approved applicants based on
-   current organisational needs and training capacity. Space is limited,
-   and qualified candidates may not be selected if we have low demand or
-   multiple applicants in the same region.
--  Members can reserve Trainer Training seats for a fee. In these cases,
-   while the seat is reserved for someone from the member institution,
-   individual candidates must still apply and be approved.
--  The Carpentries keeps a list of interested applicants and member
-   contacts who would like to be notified when the next round of Trainer
-   Training applications open. To be added to this list, please email
-   the [Instructor Training
-   Team](mailto:instructor.training@carpentries.org)
+* Instructor Trainer Training is a **10-week program held 1-2 times per year** as needed.   
+* All Instructor Trainer **candidates must apply and be approved** by a panel of current Instructor Trainers. We strongly recommend that candidates have either had   
+  * **prior experience teaching Carpentries workshops** (with existing Instructor certification) or  
+  * **significant prior training in teaching** (e.g. courses or a degree in education; experience teaching is also useful but is not the same as training)  
+* Instructor Trainer Training seats are offered to approved applicants based on current organisational needs and training capacity. Space is limited, and qualified candidates may not be selected if we have low demand or multiple applicants in the same region.  
+* Members can reserve Instructor Trainer Training seats for a fee. In these cases, while the seat is reserved for someone from the member institution, individual candidates must still apply and be approved.  
+* The Carpentries keeps a list of interested applicants and member contacts who would like to be notified when the next round of Instructor Trainer Training applications open. To be added to this list, please email the [Instructor Training Team](mailto:instructor.training@carpentries.org).
 
 #### Training and Initial Certification
 
-In order to be certified as an Instructor Trainer, all trainees must:
+To be certified as an Instructor Trainer, all trainees must:
 
--  Agree to abide by the [Code of
-   Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
-   in all communications and interactions with The Carpentries community
--  Attend weekly virtual seminar meetings
+* Agree to abide by the [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) in all communications and interactions with The Carpentries community  
+* Attend weekly virtual seminar meetings  
+  * Time commitment: 1 hour per week for 10 weeks; can miss up to 2 meetings   
+  * Meeting times are determined by a poll. Trainees may wait for a future cohort if their scheduling needs are unmet.  
+* Review How Learning Works by Susan Ambrose et al. and The Carpentries [Instructor Training Curriculum](https://preview.carpentries.org/instructor-training/)  
+  * Time commitment: approximately 2-4 hours per week  
+  * The actual time necessary for the full benefit of preparation depends on prior familiarity with content and English language proficiency  
+* Agree to participate as an Active Instructor Instructor Trainer for at least 1 year
 
-   -  Time commitment: 1 hour per week for 10 weeks; can miss up to 2
-   -  Meeting times are determined by poll. Trainees may choose to wait
-      for a future cohort if their scheduling needs cannot be met.
+Trainees who are previously certified as Carpentries Instructors must additionally:
 
--  ReviewHow Learning Works by Susan Ambrose et al. and The Carpentries
-   [Instructor Training Curriculum](https://preview.carpentries.org/instructor-training/)
+* Observe a teaching demonstration session (1 hour)  
+* Observe part of an online Instructor Training event (4 hours)
 
-   -  Time commitment: approximately 2-4 hours per week
-   -  Actual time necessary for full benefit of preparation depends on
-      prior familiarity with content and English language proficiency
+Trainees who are \*not\* previously certified as Carpentries Instructors must concurrently pursue [Instructor certification](https://carpentries.org/become-instructor/), with all steps completed or scheduled prior to receiving the Instructor Trainer badge
 
--  Agree to participate as an Active Instructor Trainer for at least 1
-   year.
+**Total time estimate** for previously certified Instructors to become certified Instructor Trainers: 35 hours (minimum) over a 3-month period
 
-Trainees who are previously certified as Carpentries Instructors must
-additionally:
-
--  Observe a teaching demonstration session (1 hour)
--  Observe part of an online Instructor Training event (4 hours)
-
-Trainees who are *not* previously certified as Carpentries Instructors
-must concurrently pursue [Instructor
-certification](https://carpentries.org/become-instructor/), with all
-steps completed or scheduled prior to badging.
-
-**Total time estimate** for previously certified Instructors to become
-certified Instructor Trainers: 35 hours (minimum) over a 3 month period.
-
-For more information, see the {{'[Instructor Training Curriculum]({})'.format(instructor_training_curriculum)}}.
+For more information, see [The Carpentries Instructor Trainer Training Curriculum](https://carpentries.github.io/trainer-training/).
 
 ### Active Status Renewal Process
 
-
 Version 1.0.1 – Approved 8 February, 2023
 
-#### Active status for Instructor Trainers is renewed annually in March.
+### Active status for Instructor Instructor Trainers is renewed annually.
 
-New Trainers who have not yet been certified for a full year and
-Trainers who have returned to Active status within the past year will
-automatically be renewed.
+New Instructor Trainers who have not yet been certified for a full year and Instructor Trainers who have returned to Active status within the past year will automatically be renewed.
 
-Active status may be renewed by either:
+#### Active status may be renewed by either:
 
-A) participating in curriculum and community activities during the prior
-   year, as described below OR
+A. participating in curriculum and community activities during the prior year, as described below OR  
+B. meet with the Director of Workshops & Training (DWIT) to catch up on curriculum and community changes and discuss plans for the coming year.
 
-B) meeting with the Director of Instructor Training (DIT) to catch up on
-   curriculum and community changes and discuss plans for the coming
-   year
+Instructor Trainers who do not renew their Active status before the deadline will have their status changed to Alumni. Instructions for Alumni returning to Active status are detailed below.
 
-Trainers who do not renew their Active status before the deadline will
-have their status changed to Alumni. Instructions for Alumni returning
-to Active status are detailed below.
+In the case of option A above, certification will be renewed automatically when records indicate that Instructor Trainers have completed all activities expected for Active Instructor Trainers, detailed below. If records are incomplete, Instructor Trainers may self-report their activities via a form. The Instructor Trainers Leadership Committee will review form responses and recommend either renewal or a meeting (option B) based on reported activities.
 
-In the case of option A, above, certification will be renewed
-automatically when records indicate that Trainers have completed all
-activities expected for Active Trainers, detailed below. If records are
-incomplete, Trainers may self-report their activities via a form. The
-Trainers Leadership Committee will review form responses and recommend
-either renewal or a meeting (option B) based on reported activities.
+#### Participation Expectations for Active Instructor Trainers
 
-Participation Expectations for Active Instructor Trainers
+To be renewed based on prior participation, an Instructor Trainer is expected to participate as follows during the 1 year period prior to renewal:
 
-In order to be renewed based on prior participation, a Trainer is
-expected to participate as follows during the 1 year period prior to
-renewal:
-
-teach at least 1 Instructor Training event, and
-
-host at least 2 teaching demos, and
-
-attend at least 4 Trainer community meetings
+* teach 1 Instructor Training event, and  
+* host 2 teaching demos, and  
+* attend 4 Instructor Trainer community meetings
 
 OR
 
-equivalent engagement with curriculum, trainees, or the Trainer
-community, as approved by the Trainers Leadership Committee
+* equivalent engagement with curriculum, trainees, or the Instructor Trainer community, as approved by the Instructor Trainers Leadership
 
-As a general rule, equivalent activities must be self-reported via form
-submission. Trainers Leadership will provide guidance to help Trainers
-choose what to share in the form, and when to select a meeting instead.
+As a general rule, equivalent activities must be self-reported via form submission. The Instructor Trainers Leadership Committee will provide guidance to help Instructor Trainers choose what to share in the form and when to select a meeting instead.
 
-Trainer Alumni Status
+Instructor Trainer Alumni Status  
+Active Instructor Trainers may elect to become inactive by requesting Instructor Trainer Alumni status at any time by contacting [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org). Alumni may also submit re-activation requests to the same address.
 
-Active Trainers may elect to become inactive by requesting Trainer
-Alumni status at any time by contacting [Instructor
-Training](mailto:instructor-training@carpentries.org). Alumni may
-also submit re-activation requests to the same address.
+### Instructor Trainer Alumni will not be permitted to:
 
-#### Trainer Alumni will not be permitted to:
+* teach Carpentries Instructor Training workshops  
+* host teaching demonstrations  
+* vote in Instructor Trainer community elections
 
+Exceptions may be made at the discretion of The Carpentries Core Team. To request permission to teach or host a demo, contact [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org).
 
--  Teach Carpentries Instructor Training workshops
+### Instructor Trainer Alumni may select to:
 
--  Host teaching demonstrations
+* continue to receive Topicbox Instructor Training emails & participate in conversations  
+* continue to participate in the Slack private Instructor Trainers channel  
+* receive an annual newsletter during agreement renewal with community updates and details on how to return to Active status.
 
--  Vote in Trainer community elections
+An Instructor Trainer who wishes to return to Active status will have a different path depending on the amount of time they’ve been inactive:
 
-Exceptions may be made at the discretion of The Carpentries Core Team.
-To request permission to teach or host a demo, contact
-team@carpentries.org.
-
-#### Trainer Alumni may select to:
-
--  Continue to receive Topicbox Instructor Training emails & participate
-   in conversations
-
--  Continue to participate in the Slack private Trainers channel
-
--  Receive an annual newsletter during agreement renewal with community
-   updates and details on how to return to Active status.
-
--  A Trainer who wishes to return to Active status will have a different
-   path depending on the amount of time they’ve been inactive:
-
--  0-12 months: meet with Director of Instructor Training to catch up on
-   latest news & discuss plans for re-activating
-
--  More than 12 months: review Trainer Training curriculum, observe part
-   of an Instructor Training workshop, and meet with Director of
-   Instructor Training to catch up and discuss plans, including
-   re-introduction to the Trainer community via meetings or other
-   arrangements.
+* 0-12 months: Meet with the Director of Workshops & Training to learn about curriculum updates & discuss plans for re-activating  
+* more than 12 months: review Instructor Trainer Training curriculum, observe part of an Instructor Training workshop, and meet with the Director of Workshops & Training to review and discuss plans, including re-introduction to the Instructor Trainer community via meetings or other arrangements.
 
 ## Offboarding
 
-### Trainer Alumni
+### Instructor Trainer Alumni 
 
+Active Instructor Trainers may elect to become inactive at any time if they expect to be unavailable to participate in the Instructor Trainer Roles and Responsibilities for 1 year or more. Active Instructor Trainers may also have their role changed to Instructor Trainer Alumni if they do not [renew their Active status](https://docs.google.com/document/d/1XN7cWRNjeu5tgWPxUlSz611RXi6bcGjkkUMUDu7iwaw/edit#heading=h.cp4it9i4qwtc) during the annual renewal period. 
 
-Active Trainers may elect to become inactive at any time if they expect
-to be unavailable to participate in the Trainer Roles and
-Responsibilities for 1 year or more. Active Trainers may also have their
-role changed to Trainer Alumni if they do not renew their [Active
-status](#active-status-renewal-process) during the annual renewal
-period.
+Instructor Trainer Alumni will not be permitted to:
 
-Trainer Alumni will not be permitted to:
+* teach Carpentries Instructor Training workshops,   
+* host teaching demonstrations or   
+* vote in Instructor Trainer community elections
 
--  Teach Carpentries Instructor Training workshops,
--  Host teaching demonstrations, or
--  Vote in Trainer community elections
+Instructor Trainer Alumni may elect to:
 
-Trainer Alumni may elect to:
-
--  Continue to receive Topicbox Instructor Training emails & participate
-   in conversations
--  Remain in the Slack private Trainers channel
--  Attend Trainer meetings
+* continue to receive Topicbox Instructor Training emails & participate in conversations  
+* remain in the Slack private Instructor Trainers channel  
+* attend Instructor Trainer meetings
 
 ## Communication and Collaboration Spaces
 
-
 ### Community Calendar
 
-All regularly scheduled Trainer community meetings and teaching
-demonstrations hosted by Trainers are listed on The Carpentries
-[Community Calendar](https://carpentries.org/community/#community-events).
-Etherpad
+All regularly scheduled Instructor Trainer community meetings and teaching demonstrations hosted by Instructor Trainers are listed on The Carpentries [Community Calendar](https://carpentries.org/community/#community-events). Below is a list of Etherpads relevant to serving as an Instructor  Trainer. 
 
-Below is a list of Etherpads relevant to serving as an Instructor
-Trainer.
-
--  [Trainer Meetings](https://pad.carpentries.org/trainers): Used for
-   monthly Trainer meetings.
--  [Teaching Demonstrations](https://pad.carpentries.org/teaching-demos):
-   Signup sheet for teaching demos. This may be used to monitor
-   registration for upcoming events. For making changes to the schedule,
-   [instructions](#teaching-demonstrations)
--  [Instructor Training Etherpad Template](https://pad.carpentries.org/ttt-template): Structured template that may be copied and pasted to create an Etherpad for any
-   Instructor Training event.
--  [Pad-of-pads](https://pad.carpentries.org/pad-of-pads): A list of
-   our most commonly used Etherpads and other resources.
+* [Instructor Trainer Meetings](https://pad.carpentries.org/trainers): Used for monthly Instructor Trainer meetings.   
+* [Teaching Demonstrations](https://pad.carpentries.org/teaching-demos): Signup sheet for teaching demos. This may be used to monitor registration for upcoming events. For making changes to the schedule, see the instructions below.(\#)  
+* [Instructor Training Etherpad Template](https://pad.carpentries.org/ttt-template): Structured template that may be copied and pasted to create an Etherpad for any Instructor Training event.  
+* [Pad-of-pads](https://pad.carpentries.org/pad-of-pads): A list of our most commonly used Etherpads and other resources.
 
 ### GitHub Repositories
 
-
--  [carpentries/instructor-training](https://github.com/carpentries/instructor-training):
-   the Instructor Training Curriculum. Specific suggestions or
-   observations regarding curriculum content should be directed to
-   issues or pull requests here for further discussion.
--  [carpentries/trainers](https://github.com/carpentries/trainers):
-   the Trainer community repository. Includes archives of Trainer
-   meeting notes, Trainers Leadership materials and proposals, and
-   discussions of interest to the Trainer community.
--  [carpentries/training-template](https://github.com/carpentries/training-template):
-   the website template used for Instructor Training events
--  [carpentries/instructor-training-bonus-modules](https://github.com/carpentries/instructor-training-bonus-modules):
-   the Instructor Training Bonus Module Curriculum.
--  [data-lessons/instructor-training](https://github.com/data-lessons/instructor-training):
-   (INACTIVE - do not contribute here unless asked to do so.) Sandbox
-   repository that has been used to test changes to Instructor Training
-   course material.
+* [carpentries/instructor-training](https://github.com/carpentries/instructor-training): the Instructor Training Curriculum. Specific suggestions or observations regarding curriculum content should be directed to issues or pull requests here for further discussion.   
+* [carpentries/Instructor Trainers](https://github.com/carpentries/trainers): the Instructor Trainer community repository. Includes archives of Instructor Trainer meeting notes, Instructor Trainers Leadership materials and proposals, and discussions of interest to the Instructor Trainer community.   
+* [carpentries/training-template](https://github.com/carpentries/training-template): the website template used for Instructor Training events  
+* [carpentries/instructor-training-bonus-modules](https://github.com/carpentries/instructor-training-bonus-modules): the Instructor Training Bonus Module Curriculum.   
+* [data-lessons/instructor-training](https://github.com/data-lessons/instructor-training): (INACTIVE \- do not contribute here unless asked to do so.) Sandbox repository that has been used to test changes to Instructor Training course material. 
 
 ### Slack
 
+[Join](https://swc-slack-invite.herokuapp.com/) The Carpentries Slack workspace.  To follow conversations relevant to this role, you should join the following channels:
 
-[Join](https://swc-slack-invite.herokuapp.com/) The Carpentries Slack
-workspace. To follow conversations relevant to this role, you should
-join the following channels:
+* **\#trainers**: a private channel open to only Instructor Trainers and members of The Carpentries Core Team used to discuss anything related to Instructor Training  
+* **\#welcome**: new instructor trainees are often directed here to introduce themselves upon joining Slack. 
 
--  **#trainers**: a private channel open to only Instructor Trainers and
-   members of The Carpentries Core Team used to discuss anything related
-   to Instructor Training
--  **#welcome**: new Instructor trainees are often directed here to
-   introduce themselves upon joining Slack.
+Instructor Trainers may also wish to join:
 
-Trainers may also wish to join:
+* **\#Instructor-training**: this low-traffic channel is open to the full community for questions or conversations related to Instructor Training  
+* **\#jobs**: recruit more Carpentries folks to build your community at work, or find a new post that values Carpentries credentials
 
--  **#Instructor-training**: this low-traffic channel is open to the
-   full community for questions or conversations related to Instructor
-   Training
--  **#jobs**: recruit more Carpentries folks to build your community at
-   work, or find a new post that values Carpentries credentials
-
-New to Slack? Check out our [Slack Quick Start Guide](https://docs.carpentries.org/topic_folders/communications/tools/slack-and-email.html#slack-quick-start-guide)!
+New to Slack? Check out our [Slack Quick Start Guide](https://docs.carpentries.org/topic_folders/communications/tools/slack-and-email.html#slack-quick-start-guide)\!
 
 ### TopicBox
 
-You can access The Carpentries mailing lists from
-[TopicBox](https://carpentries.topicbox.com/latest). Below is a list
-of those relevant to the activities and programs covered by this
-handbook.
+You can access The Carpentries mailing lists from [TopicBox](https://carpentries.topicbox.com/latest). Below is a list of those relevant to the activities and programs covered by this handbook.
 
--  [Instructor Trainers](https://carpentries.topicbox.com/groups/trainers): This is the primary communications channel for Trainers. All Active Trainers are required to be on this list. It is used for community announcements and occasional discussions about issues relevant to Instructor Training or the Trainer community.
--  [Discuss](https://carpentries.topicbox.com/groups/discuss): This general community list is one of The Carpentries’ oldest channels and is a useful way for Trainers to keep up with news and events from the broader community.
+* [Instructor Trainers](https://carpentries.topicbox.com/groups/trainers): This is the primary communication channel for Instructor Trainers. All active Instructor Trainers are required to be on this list. It is used for community announcements and occasional discussions about issues relevant to Instructor Training or the Instructor Trainer community.  
+* [Discuss](https://carpentries.topicbox.com/groups/discuss): This general community list is one of The Carpentries’ oldest channels and is a useful way for Instructor Trainers to keep up with news and events from the broader community.
 
-To join or view the archives of one or more Carpentries mailing lists,
-you will need to create a login on
-[TopicBox](https://carpentries.topicbox.com/latest). Once you have
-done this, you can scroll through the list of groups and select “Join
-the Conversation” (for open mailing) or “Request to Join” (for those
-mailing lists requiring administrator approval).
+To join or view the archives of one or more Carpentries mailing lists, you will need to [create a login on TopicBox](https://carpentries.topicbox.com/latest). Once you have done this, you can scroll through the list of groups and select “Join the Conversation” (for open mailing) or “Request to Join” (for those mailing lists requiring administrator approval). 
 
 ### Meetings
 
-Trainer meetings are scheduled at two time slots, twice monthly. Each
-month includes a primary, “discussion” meeting, where Trainers are
-invited to discuss upcoming trainings or events they have recently led,
-and receive updates on recent developments from the community and Core
-Team. The second time slot is used on an “as needed” basis, and may be
-used for focused discussion on a specific topic or cancelled.
+Instructor Trainer meetings are scheduled at two time slots, twice monthly. Each month includes a primary, “discussion” meeting, where Instructor Trainers are invited to discuss upcoming trainings or events they have recently led, and receive updates on recent developments from the community and Core Team. The second time slot is used on an “as needed” basis, and may be used for focused discussion on a specific topic or cancelled.
 
-Meetings are open to Instructor Trainers, Trainer trainees, and invited
-guests. Anyone else with interest in attending a Trainer meeting should
-first contact the [Instructor Training 
-Team](mailto:instructor.training@carpentries.org).
+Meetings are open to Instructor Trainers, Instructor Trainer trainees, and invited guests. Anyone else with interest in attending an Instructor Trainer meeting should first contact the [Instructor Training Team](mailto:instructor.training@carpentries.org).
 
-Meeting notes are recorded in the [Trainers Etherpad](https://pad.carpentries.org/trainers) and archived in the [Trainers repository on GitHub](https://github.com/carpentries/trainers/tree/main/minutes).
+Meeting notes are recorded in the [Instructor Trainers Etherpad](http://carpentries/trainers) and [archived in the Instructor Trainers repository on GitHub](https://github.com/carpentries/trainers/tree/main/minutes).
 
 ## Step-by-Step Guides
 
 ### Quarterly Scheduling Calendar
 
-Instructor Training events and Teaching Demonstrations are scheduled on
-a quarterly basis. Refer to this schedule for planning and signing up to
-support events, using instructions below.
+Instructor Training events and Teaching Demonstrations are scheduled on a quarterly basis. Refer to this schedule for planning and signing up to support events, using the instructions below.
 
-.. csv-table:: Schedule 
-   :widths: 20, 20, 20, 20, 20
-   :file: ../_includes/calendar.csv
-   :header-rows: 1
+| For the period | 1 Jan \- 31 Mar (Q1) | 1 Apr \- 30 Jun (Q2) | 1 Jul \- 30 Sep (Q3) | 1 Oct \- 31 Dec (Q4) |
+| :---- | :---- | :---- | :---- | :---- |
+| Signups open on | 15 Nov | 15 Feb | 15 May | 15 Aug |
+| Responses due by | 30 Nov | 28 Feb | 31 May | 31 Aug |
+| Calendar published by | 7 Dec | 7 Mar | 7 Jun | 7 Sept |
 
 ### Training events
 
 #### Sign up to Teach an Instructor Training Event
 
--  When signups open, Trainers will receive an email via Topicbox asking them to share their availability for the upcoming quarter in a Google form.
--  After the response deadline has passed, a Carpentries Core Team member will create a draft schedule and confirm events with individual Trainers.
--  We ask that Trainers keep available dates open until they have received confirmation of a training date or notification that they have not been scheduled for the quarter.
--  Once all events have been confirmed, the schedule is posted to the 
-{{'[Instructor Training Calendar]({}/training_calendar)'.format(instructor_training_curriculum)}}
+* When signups open, Instructor Trainers will receive an email via Topicbox asking them to share their availability for the upcoming quarter in a Google form based on the dates provided.   
+* After the response deadline has passed, a Carpentries Core Team member will create a draft schedule and confirm events with individual Instructor Trainers.   
+* We ask that Instructor Trainers keep available dates open until they have received confirmation of a training date or notification that they have not been scheduled for the quarter.  
+* Once all events have been confirmed, the schedule is posted to the [Instructor Training Calendar](https://carpentries.github.io/instructor-training/training_calendar/index.html).
 
-In rare instances events may be cancelled due to low enrolment. If this happens, Trainers will be notified of potential cancellation two weeks before the event.
+In rare instances, events may be cancelled due to low enrollment. If this happens, Instructor Trainers will be notified of potential cancellation two weeks before the event.
 
 #### Cancel a Teaching Signup
 
-Once events have been scheduled, any Trainer who needs to cancel will normally be replaced by another Trainer from the community or The Carpentries Core Team.
+Once events have been scheduled, any Instructor Trainer who needs to cancel will normally be replaced by another Instructor Trainer from the community or The Carpentries Core Team. 
 
-If you need to cancel after signing up to teach an Instructor Training event, email the [Instructor Training Team](mailto:instructor.training@carpentries.org). If your event is less than 2 weeks away, please include “urgent” in your subject line. For last minute emergencies (e.g. illness on the day of an event), additionally consider using Slack to the #trainers channel, tagging members of the [Core Team](https://carpentries.org/team/).
+If you need to cancel after signing up to teach an Instructor Training event, email the [Instructor Training Team](mailto:instructor.training@carpentries.org). If your event is less than 2 weeks away, please include “urgent” in your subject line. For last-minute emergencies (e.g. illness on the day of an event), additionally consider using Slack to the \#Instructor Trainers channel, tagging members of the [Core Team](https://carpentries.org/team/).
 
 #### Teach Instructor Training
 
-
 ##### Preparation and Instruction
 
-Guidelines on preparing to teach an Instructor Training Event can be found in the Trainer Notes section of the {{'[Instructor Training Curriculum]({}/instructor/instructor-notes.html)'.format(instructor_training_curriculum)}}.
+Guidelines on preparing to teach an Instructor Training Event can be found in the  [Instructor Trainer Notes section of the Instructor Training Curriculum](https://carpentries.github.io/instructor-training/guide/index.html)
 
 ##### Tracking Training Event Attendance
 
-During an Instructor Training event, Trainers are asked to record attendance for all trainees [using a spreadsheet similar to this](https://docs.google.com/spreadsheets/d/1RjiM8tL6CToMwGO2w7GAQwWHfYPb82RrQfuflF7hMjU/edit#gid=0). This spreadsheet will be created by the Core Team and shared with Trainers a week prior to their event. Attendance may be taken at the beginning of an event. In addition, Trainers are asked to observe continued attendance for all participants and annotate the attendance sheet if a trainee is absent for more than 1 hour on any day. Accurate records of time missed will allow the Core Team to determine appropriate makeup options for trainees who wish to complete checkout.
-
-#### Self-Organise a Private Instructor Training Event
-
-##### Requirements
-
-In limited circumstances, Trainers may self-organise an Instructor
-Training event for a specific group. This requires:
-
--  **2 or more Trainers** to teach
--  **Approved trainees**, either paid through membership or admitted as
-   a sponsored group\*
--  **Advance notice**: find quarterly scheduling dates for events that
-   use Carpentries infrastructure, or 30 days for fully independent
-   events
-
-To inquire about group sponsorship, contact the [Instructor Training
-Team](mailto:instructor.training@carpentries.org).
-
-##### Use The Carpentries’ infrastructure
-
-Self-organised trainings can choose whether or not to make use of
-Carpentries infrastructure. This includes:
-
--  **Eventbrite registration**, using our event template. This template
-   includes a prompt for trainees to fill out the Profile Creation Form
-   in {{'[AMY]({})'.format(amy_link)}}, an essential step to tracking their progress through
-   checkout. Trainers will have access to registration data and can make
-   changes to the Eventbrite page as needed.
--  **Carpentries Zoom** room to use for virtual events
-
-If you would like to make use of these, we ask that you provide notice
-of your event prior to the quarterly scheduling deadlines.
-
-**If you do not use The Carpentries’ Eventbrite template**, please
-consider adding a prompt that directs registrants to complete our
-{{'[profile creation form]({}/forms/request_training/)'.format(amy_link)}} in your
-own registration system. This will ensure that we have the data we need
-to certify your trainees.
-
-##### How to Request a Self-Organised Instructor Training Event
-
-If your event meets the requirements noted above, please use [this
-google form to submit your request](https://forms.gle/WQGh5GVwhCBaY7xk6). For questions, {{'[email the Instructor Training Team](mailto:{})'.format(instructor_training_email)}}.
+During an Instructor Training event, Instructor Trainers are asked to record attendance for all trainees using [a spreadsheet similar to this](https://docs.google.com/spreadsheets/d/1RjiM8tL6CToMwGO2w7GAQwWHfYPb82RrQfuflF7hMjU/edit#gid=0). This spreadsheet will be created by the Core Team and shared with Instructor Trainers a week before their event. Attendance may be taken at the beginning of an event. In addition, Instructor Trainers are asked to observe continued attendance for all participants and annotate the attendance sheet if a trainee is absent for more than 1 hour on any day. Accurate records of time missed will allow the Core Team to determine appropriate makeup options for trainees who wish to complete checkout.
 
 ### Teaching Demonstrations
 
 #### Sign up to Host a Demo
 
-Signups for teaching demonstrations are normally announced with
-Instructor Training event signups, but may be opened at other times if
-there is a need for additional sessions.
+Signups for teaching demonstrations are normally announced with Instructor Training event signups, but may be opened at other times if there is a need for additional sessions.
 
--  When signups open, Trainers will receive an email via Topicbox asking them to sign up for teaching demos in the coming quarter via Calendly.
--  Calendly will automatically send an event confirmation email and calendar invitation.
--  After the response deadline has passed, a Carpentries Core Team member will create a list of events to post to the [Teaching Demonstrations Etherpad](https://pad.carpentries.org/teaching-demos).
+* When signups open, Instructor Trainers will receive an email via Topicbox asking them to sign up for teaching demos in the coming quarter via Calendly.   
+* Calendly will automatically send an event confirmation email and calendar invitation.   
+* After the response deadline has passed, a Carpentries Core Team member will create a list of events to post to the [Teaching Demonstrations Etherpad](https://pad.carpentries.org/teaching-demos). 
 
 #### Prepare for a Demo
 
-
--  If you would like to review an example teaching demo, there is [a recording of one here](https://carpentries.github.io/instructor-training/guide/index.html#vi-teaching-demonstration-tips).
--  Trainer-suggested scripts and other tips and tricks for hosting these    sessions are included in the [Instructor Notes](https://carpentries.github.io/instructor-training/guide/index.html#vi-teaching-demonstration-tips) section of the Instructor Training Curriculum.
--  Get acquainted with using [Zoom](https://docs.carpentries.org/topic_folders/communications/tools/zoom_rooms.html) for videoconferencing.
--  Check your Calendly confirmation email for the Host Key to use on Zoom, and keep this where you can find it. This will be necessary to allow trainees to screen share during your demo.
--  A day or two before the demo, send a reminder to trainees based on [this email template] (https://docs.carpentries.org/topic_folders/instructor_training/email_templates_trainers.html#reminder-teaching-demo).  This often prompts questions or cancellations. You may wish to use this [community-developed script](https://github.com/jcoliver/auto-demo-email) to generate your emails.
--  Select a suitable starting point in the lesson for each trainee. Suggested start points are available in the [Instructor Training Curriculum (under Extras)](https://carpentries.github.io/instructor-training/demo_lessons/index.html).
-   Do not have them start in the middle of an episode. Note that some lessons (e.g., the Software Carpentry R lesson using inflammation data) have supplementary episodes. Do not pick from those.
--  If a trainee has selected a lesson that is not on the list above, you may ask them to choose a different lesson or, if you are familiar with the lesson, you may choose a start point and allow them to use it anyway. Be sure the start point does not require any setup or rely on any dependencies from prior episodes.
+* If you would like to review an example teaching demo, there is a [recording of one here](https://www.youtube.com/watch?v=3NCpPk8jvQo).  
+* Instructor Trainer-suggested scripts and other tips and tricks for hosting these sessions are included in the [Instructor Notes](https://carpentries.github.io/instructor-training/instructor/instructor-notes.html) section of the Instructor Training Curriculum.  
+* Get acquainted with using [Zoom](https://docs.carpentries.org/topic_folders/communications/tools/zoom_rooms.html) for videoconferencing.  
+* Check your Calendly confirmation email for the Host Key to use on Zoom, and keep this where you can find it. This will be necessary to allow trainees to screen share during your demo.  
+* A day or two before the demo, send a reminder to trainees based on this [email template](https://docs.carpentries.org/topic_folders/instructor_training/email_templates_trainers.html#reminder-teaching-demo). This often prompts questions or cancellations. You may wish to use this [community-developed script](https://github.com/jcoliver/auto-demo-email) to generate your emails.  
+* Trainees will select their starting point. Suggested start points are available in the [Instructor Training Curriculum (under More)](https://carpentries.github.io/instructor-training/instructor/demo_lessons.html).   
+* If a trainee has selected a lesson that is not on the list above, you may ask them to choose a different lesson or, if you are familiar with the lesson, you may choose a start point and allow them to use it anyway. Be sure the start point does not require any setup or rely on any dependencies from prior episodes.
 
 #### Host a Demo
 
--  Go to the Zoom room. The link is in [the Etherpad](https://pad.carpentries.org/teaching-demos).
--  Once everyone is in the call (with their audio and video working), remind them of the Code of Conduct, explain the procedure for the demo session, and remind them that trainees have to be able to teach from any episode from their chosen lesson. Ask whether anyone has only prepared for one episode, and if so, suggest strongly they reschedule.
--  Let trainees know that you will not tell them if they passed during the session, but instead will follow up with an email afterward. It can help to remind them that this is not a high stakes test but a friendly opportunity for feedback.
--  Ask those not presenting to give feedback using the same [positive-vs-negative and content-vs-presentation rubric](https://carpentries.github.io/instructor-training/11-practice-teaching/index.html#giving-feedback) used in training. For a full session (5 trainees), they should add feedback to the Etherpad for you to summarise. If you have fewer people, you may have them take turns sharing verbally.
--  Give each trainee a few moments to get set up and initiate screen sharing before counting down to begin. Start a timer.
--  While they present, consider feedback, and take notes privately. Use this [rubric](https://carpentries.github.io/instructor-training/demos_rubric/) as a guide, focusing on feedback that you think will be most necessary or helpful for the trainee as they progress toward   teaching.
--  After the timer ends, trainees should wrap up and share feedback on themselves first.
--  Summarise or share other trainees’ feedback as time allows, concluding with your own comments. It is sometimes necessary to (gently) disagree with feedback from another trainee.
--  Do NOT tell a trainee whether they passed immediately after their demo.
--  After everyone has gone, if all of trainees passed, it is ok to tell the group. Either way, tell the group you will email them afterward to follow up.
--  More tips can be found in the [instructor notes](https://carpentries.github.io/instructor-training/guide/index.html#vi-teaching-demonstration-tips) of the instructor training website.
+* Go to the Zoom room. The link is in the [Etherpad](https://pad.carpentries.org/teaching-demos).  
+* Once everyone is on the call (with their audio and video working), remind them of the Code of Conduct, explain the procedure for the demo session, and remind them that trainees have to be able to teach from any episode from their chosen lesson. Ask whether anyone has only prepared for one episode, and if so, suggest strongly they reschedule.  
+* Let trainees know that you will not tell them if they passed during the session, but instead will follow up with an email afterward. It can help to remind them that this is not a high stakes test but a friendly opportunity for feedback.  
+* Ask those not presenting to give feedback using the same [positive-vs-areas of improvent and content-vs-presentation rubric](https://carpentries.github.io/instructor-training/instructor/demos_rubric.html) used in training. For a full session (5 trainees), they should add feedback to the Etherpad for you to summarise. If you have fewer people, you may have them take turns sharing verbally.  
+* Give each trainee a few moments to get set up and initiate screen sharing before counting down to begin. Start a timer.  
+* While they present, consider feedback, and take notes privately. Use this [rubric](https://carpentries.github.io/instructor-training/instructor/demos_rubric.html) as a guide, focusing on feedback that you think will be most necessary or helpful for the trainee as they progress toward teaching.  
+* After the timer ends, trainees should wrap up and share feedback on themselves first.  
+* Summarise or share other trainees’ feedback as time allows, concluding with your own comments. It is sometimes necessary to (gently) disagree with feedback from another trainee.  
+* Do NOT tell a trainee whether they passed immediately after their demo.  
+* After everyone has gone, if all of trainees passed, it is ok to tell the group. Either way, tell the group you will email them afterward to follow up .  
+* More tips can be found in the [instructor notes](https://carpentries.github.io/instructor-training/instructor/instructor-notes.html) of the instructor training website.
 
 #### After a Demo: Report and Etherpad Cleanup
 
--  [Fill out this form](https://forms.gle/ZusNhyhNh4rvCmxH8) to notify The Carpentries of who passed and who did not pass.
--  Clear Etherpad of data from your session.
--  Send each trainee an email using our templates (#) letting them know
-   they [passed](https://docs.carpentries.org/topic_folders/instructor_training/email_templates_trainers.html#trainee-did-pass-teaching-demo)
-   or [did not pass](https://docs.carpentries.org/topic_folders/instructor_training/email_templates_trainers.html#trainee-didnt-pass-teaching-demo) the teaching demo. If needed, let them know the reason they did not pass and asking them to retry.
+* Fill out [this form](https://forms.gle/ZusNhyhNh4rvCmxH8) to notify The Carpentries of who passed and who did not pass.  
+* Save Etherpad by selecting the “star” at the top right of the screen  
+* Clear Etherpad of data from your session.  
+* Send each trainee an email using our templates (\#) letting them know they [passed](https://docs.carpentries.org/topic_folders/instructor_training/email_templates_trainers.html#trainee-passed-teaching-demo) or [did not pass](https://docs.carpentries.org/topic_folders/instructor_training/email_templates_trainers.html#trainee-invited-to-repeat-teaching-demo) the teaching demo. If needed, let them know the reason they did not pass and ask them to retry.
 
 #### Cancel a Demo
 
 **If no trainees have signed up:**
 
-1. Remove the event from the [Etherpad](http://pad.carpentries.org/trainers). It is important
-to do this first to prevent anyone from signing up! You have permission to remove your own demo and do not need to ask.
-2. Notify [Instructor Training](mailto:instructor.training@carpentries.org) to let us know that your event needs to be removed from the [Community Calendar](https://carpentries.org/community/#community-events).
+1. Remove the event from the [Etherpad](http://pad.carpentries.org/trainers). It is important to do this first to prevent anyone from signing up\! You have permission to remove your own demo and do not need to ask.  
+2. Notify [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org) to let us know that your event needs to be removed from the [Community Calendar](https://carpentries.org/community/#community-events).
 
 **If trainees have signed up:**
 
-1. If there is enough time, post a message in the #trainers Slack channel and/or send an email to trainers@lists.carpentries.org to find someone can take your place. (You may choose to skip this step, e.g. if there are only 1-2 people signed up.)
-
-   1. If someone can take your place, make sure to confirm with them and have them add their information on the Etherpad.
-   2. Make sure someone on the Core Team knows so they can be added to the calendar invitation. When in doubt, email [InstructorTraining](mailto:instructor.training@carpentries.org).
-   3. You are done!- Disregard steps 2+ below!
-
-2. If step 1 is skipped or unsuccessful, email the trainees (#) to let them know that the demo has been cancelled, and ask them to sign up for a different session.
-3. Remove the event from the [Etherpad](http://pad.carpentries.org/trainers).
-4. Notify [Instructor Training](mailto:instructor.training@carpentries.org) to let us know that your event needs to be removed from the [Community Calendar](https://carpentries.org/community/#community-events).
-
-### Trainer Community
+1. If there is enough time, post a message in the \#Trainers Slack channel and/or send an email to [Instructor Trainers@lists.carpentries.org](mailto:trainers@lists.carpentries.org) to find someone who can take your place. (You may choose to skip this step, e.g. if there are only 1-2 people signed up.)  
+   1. If someone can take your place, confirm with them and have them add their information on the Etherpad.   
+   2. Ensure someone on the Core Team knows so they can be added to the calendar invitation. When in doubt, email [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org).  
+   3. You are done\!  
+2. If step 1 is skipped or unsuccessful, email the trainees to let them know the demo has been cancelled, and ask them to sign up for a different session.  
+3. Remove the event from the [Etherpad](http://pad.carpentries.org/trainers).  
+4. Notify [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org) to let us know that your event needs to be removed from the [Community Calendar](https://carpentries.org/community/#community-events).
 
 #### Share lessons learned from a Training event or Demo
 
-Sharing after teaching or hosting a demo helps everyone to think about
-their practice, learn from what you have learned, and consider ways we
-can make our program better. To make the most of this opportunity,
-consider sharing details about:
+Sharing your experience after teaching or hosting a demo helps everyone to think about their practice, learn from what you have learned, and consider ways to make our program better. To make the most of this opportunity, consider sharing details about:
 
--  **What content you spent extra time on**. This tells people what you
-   and your trainees considered to be most interesting, most important,
-   or most challenging. Sometimes there are good things to explore
-   behind those choices.
--  **What content you skipped**. This helps newer Trainers consider how
-   to cut when they need to. It also helps Maintainers think about areas
-   where future cuts or adjustments should be made in the curriculum.
--  **What choices you made to manage engagement**. Every group is
-   different! Did you need to work harder to allow everyone to
-   contribute? Mix up groups to break up some low energy combinations?
-   Maybe you embraced your introverts and did more work in the Etherpad
-   this time. Sharing choices you made in response to ‘reading the room’
-   (or your feedback) helps others expand their choice options and
-   discussion can inspire new ideas for handling tough problems.
--  **Subjective details.**\ “It went well” is great but hard to learn
-   from. Why do you think particular things worked for your group? In
-   what areas do you feel uncertain about your outcomes, and why? There
-   are no right or wrong answers to questions like this, but your
-   opinions tell a story that helps others reflect and understand their
-   own practice.
+- **What content you spent extra time on**. This tells people what you and your trainees considered most interesting, most important, or most challenging. Sometimes there are good things to explore behind those choices.  
+- **What content you skipped**. This helps newer Instructor Trainers consider how to cut when they need to. It also helps Maintainers think about areas where future cuts or adjustments should be made in the curriculum.  
+- **What choices you made to manage engagement**. Every group is different\! Did you need to work harder to allow everyone to contribute? Mix up groups to break up some low energy combinations? Maybe you embraced your introverts and did more work in the Etherpad this time. Sharing choices you made in response to ‘reading the room’ (or your feedback) helps others expand their choice options and discussion can inspire new ideas for handling tough problems.  
+- **Subjective details.** “It went well” is great but hard to learn from. Why do you think particular things worked for your group? In what areas do you feel uncertain about your outcomes, and why? There are no right or wrong answers to questions like this, but your opinions tell a story that helps others reflect and understand their own practice.  
 
-Don’t remember? You’ll be surprised how much you can refresh in 5
-minutes! A quick review of your Etherpad, notes, etc. really helps to
-get ideas flowing before the meeting.
+Don’t remember? You’ll be surprised how much you can refresh in 5 minutes\! A quick review of  your Etherpad, notes, etc. really helps to get ideas flowing before the meeting. 
 
-#### Propose a Meeting Topic
-
-If you’d like to connect with others from the community on a particular
-topic, you do not need to wait for someone else to host a meeting!
-Propose a topic and invite others to join you. Core Team members are
-always available to host or co-host.
-
-To suggest a meeting topic, Go to the [new issues page in the Trainers
-repository](https://github.com/carpentries/trainers/issues/new/choose)
-and select the Get started button for “Template for Trainer Meeting
-Topics”. Fill in the form, including a title for the Issue (which can be
-the same as the title of the proposed Trainer meeting topic). Before
-proposing a topic, we suggest you view topics that have already been
-proposed or scheduled at the [Trainers meeting scheduling
-page](https://github.com/orgs/carpentries/projects/4/views/2). You
-may wish to specify whether you think a short discussion (during a
-standard meeting after pre/post workshop conversations) or a dedicated
-meeting would be more appropriate.
-
-Example discussion topics (always worthy of a repeat by request!):
-
--  Working on your teaching practice
--  Teaching about the Code of Conduct
--  Supporting trainees in a local community
--  Teaching demo hosting practices
-
-#### (Co-)Host a Trainer Meeting
-
-
-To host a meeting, review the meetings that are already scheduled
-(“Upcoming Meetings” tab) and those that have yet to be scheduled
-(“Proposed” tab) at the [Trainers meeting scheduling
-page](https://github.com/orgs/carpentries/projects/4/views/2). If you
-find a topic you would be interested in hosting, (1) select the title of
-the meeting you are interested in (in the “Upcoming Meetings” or
-“Proposed” tabs) for more information about the proposed topic; then (2)
-scroll down to leave a comment in the dialog box below the proposal to
-indicate if you would like to host or co-host and which meeting(s) you
-can attend.
-
-The [trainer meeting pad](https://pad.carpentries.org/trainers) has information on the meetings or the [meeting minutes](https://github.com/carpentries/trainers/tree/main/minutes) for information about past meetings.
-
-If you sign up to host a meeting by yourself, a Core Team Trainer will be your co-host. Hosting duties can be split in any way, but a common example is:
-
-Host:
-
--  Prepares agenda for discussion (Note: template for pre/post
-   discussion and announcements will be prepared by Core Team)
--  Selects and leads a warmup activity
--  Facilitates meeting (including pre/post discussion if scheduled that
-   day)
-
-Co-host:
-
--  Claims “host” role in Zoom, enables waiting room if desired
--  Takes notes
--  Assumes host role if host loses connection
+To share these ideas, please join one of the monthly Instructor Trainer meetings. There will always be time allotted to share feedback. 
 
 ## Resources
 
 ### Community-developed Resources
 
+* [Instructor Trainers Folder](https://drive.google.com/drive/folders/10ncHtw4ZtNZD0ozW0rG5C-Q4yFetRY1t?usp=sharing): This folder contains documents created by or for Instructor Trainers. Anyone may add or store content relevant to Carpentries Instructor Training or the Instructor Trainer community. Contents may not be up to date.   
+* Neil’s [TTT Planning Document](https://docs.google.com/spreadsheets/d/1TFcgQaj527EenrSekPiDo9WVY_Vw-HOOzp2MlAp83Bw/edit?usp=sharing): A useful item in the Instructor Trainers folder, this spreadsheet can help you equitably divide up teaching duties for an Instructor Training event as well as keep track of section start and stop times in two time zones.  
+* Jeff’s [email templating script for demos](https://github.com/jcoliver/auto-demo-email): this community-developed resource can lighten the load of preparing for your teaching demonstration.
 
--  [Trainers Folder](https://drive.google.com/drive/folders/10ncHtw4ZtNZD0ozW0rG5C-Q4yFetRY1t?usp=sharing):  This folder contains documents created by or for Trainers. Anyone may add or store content relevant to Carpentries Instructor Training or the Trainer community. Contents may not be up to date.
--  Neil’s [TTT Planning Document](https://docs.google.com/spreadsheets/d/1TFcgQaj527EenrSekPiDo9WVY_Vw-HOOzp2MlAp83Bw/edit?usp=sharing): A useful item in the Trainers folder, this spreadsheet can help you equitably divide up teaching duties for an Instructor Training event as well as keep track of section start and stop times in two time zones.
--  [Jeff’s email templating script for demos](https://github.com/jcoliver/auto-demo-email): this community-developed resource can lighten the load of preparing for your teaching emonstration.
+### Email Templates for Instructor Trainers
 
-### Email Templates for Trainers
-
-#### Private Events Only: Pre-Training (1 week before) Email Sent by Trainer or Member Contact to Trainees
-
-Note: For most events, the Core Team manages communications with
-trainees. This template is to be used for private events when Trainers
-or local organisers are handling communications with trainees. For any
-questions about how or when to use this template, email [Instructor
-Training](mailto:instructor.training@carpentries.org).
-
-Subject: Information for Your Upcoming Instructor Training with The
-Carpentries on DATE_TIME
-
-Hello everyone,
-
-Thank you for registering for The Carpentries Instructor Training on
-DATE_TIME_TIMEZONE (Click to find the start time in your timezone). This
-email contains important information to help you prepare for the
-training - please review it carefully and let me know if you have any
-questions.
-
-**About Carpentries Instructor Training**
-
-This training is designed for people who want to become certified
-Carpentries instructors. We recommend that you be familiar with at least
-one of the technologies that we teach (R, Python, the Unix bash shell,
-SQL, OpenRefine, spreadsheet software, and/or Git) before taking
-Instructor Training. This training will not teach any of those subjects,
-but will instead focus on developing skill and knowledge about
-evidence-based teaching practices and workshop procedures.
-
-For more information about what will be covered at this training as well
-as a sample schedule, check out our Instructor Training Curriculum (#).
-
-**Connecting to Your Training**
-
-This training will be conducted using [ platform, download instructions
-etc. ] access the training: [ link to join ] Password is [ password ].
-
-[training website/collaborative document] has more details about the
-event.
-
-**Preparing for Your Training**
-
-Before your training, please visit the Preparing for Instructor Training
-page for complete instructions. A brief summary of these instructions is
-as follows
-
--  Complete our Pre-training Survey. [ NOTE to Trainer: This list item
-   should include a custom survey link that is generated by the training
-   website template. ]
--  Select a lesson to use for teaching practice sessions, spending no
-   more than 20-30 minutes to prepare. There are “Recommended Episodes”
-   at the bottom of the page
--  Please review the following:
-
-   -  “The Science of Learning”
-   -  “The Carpentries Annual Report”
-
--  Create a profile in The Carpentries database.
-
-   -  This is necessary for you to be certified as a Carpentries
-      Instructor. Please select “Profile Creation for Pre-approved
-      Trainees” and enter the code [NOTE to Trainer: you may use your
-      workshop slug as a registration code.]
-
-**Checkout: The Instructor Certification Process**
-
-After your training, you will be asked to complete three follow-up tasks
-to become a certified Instructor. These requirements are detailed on the
-Checkout Instructions page and will be discussed at your training.
-
-**Cancellations and Attendance**
-
-We would like to be able to use all of the seats allocated to us in our
-membership for this event. If you are unable to attend, please let us
-know as soon as possible.
-
-If you miss more than 1 hour of the training, you may be marked absent.
-Instructor certification cannot be completed without full attendance at
-an Instructor Training event. If you unexpectedly need to miss more than
-1 hour of your event, please contact us.
-
-More information on The Carpentries cancellation and attendance policy
-is available in The Carpentries Handbook.
-
-If you have any questions about the training, the material, or anything
-else, please contact us.
-
-Excited for the workshop!
-
-Best, [Name]
 
 #### Reminder Teaching Demo
-
 
 Note: There are instructions under “Preparing for a Demo”
 
@@ -701,221 +321,119 @@ Subject: The Carpentries teaching demonstration
 
 Hi,
 
-According to the Teaching Demo Etherpad you have signed up to give an
-online teaching demo on [ date ] at [ time ] (Local time: [
-timeanddate.com link ]). I will be the Trainer teaching the session.
+According to the Teaching Demo Etherpad you have signed up to give an online teaching demo on \[ date \] at \[ time \] (Local time: \[ timeanddate.com link \]) as part of your checkout. I will be the Instructor Trainer hosting the session.
 
-I wanted to be sure you know that I may give you any segment of the
-lesson you prepared to teach, so you must be ready to teach any part of
-your chosen lesson. Some people prepare to teach only 5 minutes from a
-particular section and they often have to reschedule as they seldom are
-assigned the section they have prepared for.
+I wanted to be sure you know that I may give you any segment of the lesson you prepared to teach, so you must be ready to teach any part of your chosen lesson. Some people prepare to teach only 5 minutes from a particular section and they often have to reschedule as they seldom are assigned the section they have prepared for.
 
-A lesson corresponds to a single line in the lesson tables
-(https://software-carpentry.org/lessons/ ,
-http://www.datacarpentry.org/lessons/ , and
-https://librarycarpentry.org/lessons/) and a single repository on
-GitHub. Some lessons have supplementary modules, but you do not need to
-be prepared to teach the supplementary modules for your teaching
-demonstration.
+A lesson corresponds to a single line in the lesson tables (https://software-carpentry.org/lessons/ , http://www.datacarpentry.org/lessons/ , and https://librarycarpentry.org/lessons/) and a single repository on GitHub. Some lessons have supplementary modules, but you do not need to be prepared to teach the supplementary modules for your teaching demonstration.
 
-For example, if you have chosen The Unix Shell, I may assign you any
-episode listed at http://swcarpentry.github.io/shell-novice/.
+For example, if you have chosen The Unix Shell, I may assign you any episode listed at http://swcarpentry.github.io/shell-novice/.
 
-Please remember – this is not a high stakes test! This is a friendly
-opportunity to give and receive feedback on a more polished presentation
-style. In the event that I ask you to repeat your demo, I will provide
-this information with clear instructions on what to change in an email
-to you after the demo. You will only receive qualitative feedback
-publicly during the demo, not information regarding whether this
-checkout step is considered complete.
+Please remember – this is not a high stakes test\! This is a friendly opportunity to give and receive feedback on a more polished presentation style. In the event that I ask you to repeat your demo, I will provide this information with clear instructions on what to change in an email to you after the demo. You will only receive qualitative feedback publicly during the demo, not information regarding whether this checkout step is considered complete.
 
-[ sender name ]
+\[ sender name \]
 
 #### Bilingual Demo: Reminder Teaching Demo
-
 
 Subject: Carpentries instructor training: Teaching Demo
 
 Hello,
 
-Thanks for signing up to complete your “Teaching Demo” as part of the
-instructor certification process. We will meet on [ Insert Date ] at [
-Insert Time ] in this Zoom videoconferencing room (insert zoom link
-here). Please review this short bi-lingual description of how Teaching
-Demo session works
-(https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md#).
-Disclaimer: I understand Spanish better than I speak it. So, I will talk
-in Spanish as much as I can, but I will most likely give feedback about
-your teaching in English.
+Thanks for signing up to complete your “Teaching Demo” as part of the instructor certification process. We will meet on \[ Insert Date \] at \[ Insert Time \] in this Zoom videoconferencing room (insert zoom link here). Please review this short bi-lingual description of how Teaching Demo session works (https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md\#). Disclaimer: I understand Spanish better than I speak it. So, I will talk in Spanish as much as I can, but I will most likely give feedback about your teaching in English.
 
 Please let me know if you have any questions or concerns.
 
 Hola,
 
-Gracias por inscribirte para completar tu demostración de enseñanza como
-parte del proceso de certificación para instructores. Nos reuniremos [
-Insert Date ] [ insert time ] aquí: (insert zoom link here). Por favor,
-lee ésta breve descripción bilingüe de cómo funciona la sesión de
-demostración de enseñanza aquí:
-(https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md#).
-Aviso: Entiendo el español mejor de lo que hablo. Por lo tanto, voy a
-hablar en español un poco, pero es muy probable que les dé comentarios
-sobre su enseñanza en Inglés.
+Gracias por inscribirte para completar tu demostración de enseñanza como parte del proceso de certificación para instructores. Nos reuniremos \[ Insert Date \] \[ insert time \] aquí: (insert zoom link here). Por favor, lee ésta breve descripción bilingüe de cómo funciona la sesión de demostración de enseñanza aquí: (https://github.com/carpentries/latinoamerica/blob/master/traducciones/demo.md\#). Aviso: Entiendo el español mejor de lo que hablo. Por lo tanto, voy a hablar en español un poco, pero es muy probable que les dé comentarios sobre su enseñanza en Inglés.
 
 Por favor, hazme saber si tienes alguna pregunta o inquietud.
 
 Best/Saludos,
 
-[ sender name ]
+\[ sender name \]
 
 #### Trainee Invited to Repeat Teaching Demo
 
-
-Note to Trainers: Even with a template, these emails can be hard to
-compose and send! When in doubt, do not hesitate to connect with the
-Trainer community and/or Core Team for support in deciding, customising,
-or responding to questions about these messages.
+***Note to Instructor Trainers:** Even with a template, these emails can be hard to compose and send\! When in doubt, do not hesitate to connect with the Instructor Trainer community and/or Core Team for support in deciding, customising, or responding to questions about these messages.*
 
 Subject: Carpentries Instructor Training: Teaching Demo
 
-Hi [ trainee name ],
+Hi \[ trainee name \],
 
-Thank you for doing a teaching demonstration. While you demonstrated
-good [ something they did well, e.g. command of the subject material], I
-am inviting you to return for another try at the teaching demo. The
-primary reason is because [ reason ]. [ Explanation of what you would
-like to prefer instead, and why it is central to Carpentries teaching
-practices. ]
+Thank you for completing your teaching demonstration. While you demonstrated good \[ something they did well, e.g. command of the subject material\], I am inviting you to return for another try at the teaching demo. The primary reason is because \[ reason \]. \[ Explanation of what you would like to prefer instead, and why it is central to Carpentries teaching practices. \]
 
-We are excited about having you as a Carpentries instructor and we want
-to have you on board! I know it is hard to make time for these sessions,
-and I hope you will find the opportunity for additional practice and
-feedback to be worthwhile.
+We are excited about having you as a Carpentries Instructor and we want to have you on board\! I know it is hard to make time for these sessions, and I hope you will find the opportunity for additional practice and feedback to be worthwhile.
 
-I have contacted our Core Team to indicate that this session should be repeated. If you are close to the end of your checkout period, you can email [Instructor Training] (mailto:instructor.training@carpentries.org) to request an extension if you need one.
+I have contacted our Core Team to indicate that this session should be repeated. If you are close to the end of your checkout period, you can email [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org) to request an extension if you need one.
 
-Please contact us with questions!
+Please contact us with questions\!
 
 Best wishes,
 
-[ sender name ]
+\[ sender name \]
 
 #### Spanish: Trainee Invited to Repeat Teaching Demo
 
+Nota a los Instructor Trainers: Incluso con un template, este tipo de emails son difíciles de redactar y enviar\! Si tienes preguntas, no dudes en contactar con la comunidad de Instructor Trainers y/o nuestro personal para tomar decisiones, personalizar o responder preguntas sobre estos mensajes.
 
-Nota a los Trainers: Incluso con un template, este tipo de emails son
-difíciles de redactar y enviar! Si tienes preguntas, no dudes en
-contactar con la comunidad de Trainers y/o nuestro personal para tomar
-decisiones, personalizar o responder preguntas sobre estos mensajes.
+Subject: Formación para instructor de las Carpentries: Demostración de enseñanza
 
-Subject: Formación para instructor de las Carpentries: Demostración de
-enseñanza
+Hola \[nombre del aprendiz\],
 
-Hola [nombre del aprendiz],
+Gracias por realizar tu demostración de enseñanza. A pesar de que has demostrado un buen \[algo que hizo bien, puntos positivos, e.g. conocimiento de los materiales de enseñanza\], me gustaría invitarte a realizar de nuevo la demostración de enseñanza. La razón principal es \[razón\]. \[Explicar lo que te gustaría ver en el/la candidato/a, y por qué es fundamental de acuerdo a las prácticas educativas de Carpentries\].
 
-Gracias por realizar tu demostración de enseñanza. A pesar de que has
-demostrado un buen [algo que hizo bien, puntos positivos,
-e.g. conocimiento de los materiales de enseñanza], me gustaría invitarte
-a realizar de nuevo la demostración de enseñanza. La razón principal es
-[razón]. [Explicar lo que te gustaría ver en el/la candidato/a, y por
-qué es fundamental de acuerdo a las prácticas educativas de
-Carpentries].
+Esta no ha sido una decisión fácil de tomar – nos encantaría tenerte como instructor en Carpentries\! Sé que es complicado hacer tiempo para este tipo de sesiones pero espero que consideres este tiempo adicional de práctica y feedback como una oportunidad.
 
-Esta no ha sido una decisión fácil de tomar – nos encantaría tenerte
-como instructor en Carpentries! Sé que es complicado hacer tiempo para
-este tipo de sesiones pero espero que consideres este tiempo adicional
-de práctica y feedback como una oportunidad.
+Me he puesto en contacto con nuestro personal de checkout indicando que esta sesión debe repetirse. Si estás cerca de tu periodo de checkout, puedes enviar un email a instructor.training@carpentries.org para solicitar una extensión si la necesitas.
 
-Me he puesto en contacto con nuestro personal de checkout indicando que
-esta sesión debe repetirse. Si estás cerca de tu periodo de checkout,
-puedes enviar un email [Instructor
-Training](mailto:instructor.training@carpentries.org) para solicitar
-una extensión si la necesitas.
-
-No dudes en ponerte en contacto si tienes cualquier pregunta!
+No dudes en ponerte en contacto si tienes cualquier pregunta\!
 
 Saludos,
 
-[nombre del remitente]
+\[nombre del remitente\]
 
 #### Trainee Passed Teaching Demo
 
 Subject: Carpentries Instructor Training: Teaching Demo
 
-Hi [ trainee name ],
+Hi \[ trainee name \],
 
-I’m happy to sharethat you have passed your teaching demonstration! You
-demonstrated a [good command of the subject material and a solid
-understanding of The Carpentries teaching methods]. We are excited about
-having you as a Carpentries Instructor.
+I’m happy to share that you have passed your teaching demonstration\! You demonstrated a \[good command of the subject material and a solid understanding of The Carpentries teaching methods\]. We are excited about having you as a Carpentries Instructor.
 
-I’ve forwarded this information to our Core Team. If this was the last
-step in your Instructor Training checkout, you will be contacted in
-about a week.
+I’ve forwarded this information to our Core Team. If this was the last step in your Instructor Training checkout, you will be contacted in about a week. 
 
-Welcome to The Carpentries Instructor community!
+Welcome to The Carpentries Instructor community\!
 
 Best wishes,
 
-[ sender name ]
+\[ sender name \]
 
-Email Templates (Trainers: Spanish)
+Email Templates (Instructor Trainers: Spanish)
 
 #### Spanish: Trainee Did Pass Teaching Demo
 
+Subject: Formación para instructor de las Carpentries: Demostración de enseñanza
 
-Subject: Formación para instructor de las Carpentries: Demostración de
-enseñanza
+Hola \[nombre del aprendiz\],
 
-Hola [nombre del aprendiz],
-
-Me alegra informarte que has pasado tu demostración de enseñanza. Has
-demostrado un buen dominio del contenido de los materiales y de las
-metodologías de enseñanza de las Carpentries, por tanto, es un placer
-recibirte como instructor/a en las Carpentries. Ya he comunicado esta
-información a nuestro Core Team. Si esta fue la última parte de tu
-proceso de certificación, recibirás tu certificado oficial de las
-Carpentries junto con las instrucciones para inscribirte para impartir
-talleres en una semana aproximadamente. Si aún tienes que completar
-algún paso en tu proceso de certificación, asegúrate de completarlos
-antes de la fecha límite. Si tienes alguna pregunta, por favor envía un
-correo a instructor.training@carpentries.org.
+Me alegra informarte que has pasado tu demostración de enseñanza. Has demostrado un buen dominio del contenido de los materiales y de las metodologías de enseñanza de las Carpentries, por tanto, es un placer recibirte como instructor/a en las Carpentries. Ya he comunicado esta información a nuestro Core Team. Si esta fue la última parte de tu proceso de certificación, recibirás tu certificado oficial de las Carpentries junto con las instrucciones para inscribirte para impartir talleres en una semana aproximadamente. Si aún tienes que completar algún paso en tu proceso de certificación, asegúrate de completarlos antes de la fecha límite. Si tienes alguna pregunta, por favor envía un correo a instructor.training@carpentries.org.
 
 Bienvenida/o a la comunidad de las Carpentries.
 
 Saludos,
 
-[nombre del remitente]
+\[nombre del remitente\]
 
-##### Teaching demo cancelled - trainees
+#### Teaching demo cancelled \- trainees
 
-
-Subject: Teaching demo cancelled - please reschedule
+Subject: Teaching demo cancelled \- please reschedule
 
 Dear checkout participant,
 
-Thank you for signing up to do your teaching demonstration at [time in
-UTC from Etherpad] [time and date link]. Unfortunately, we need to
-cancel this session due to [reason (optional)]. There are still spots
-open in upcoming sessions on the Etherpad, and I hope you will be able
-to find one that suits your schedule.
+Thank you for signing up to do your teaching demonstration at \[time in UTC from Etherpad\] \[time and date link\]. Unfortunately, we need to cancel this session due to \[reason (optional)\]. There are still spots open in upcoming sessions on the Etherpad, and I hope you will be able to find one that suits your schedule.
 
-I know it is hard to make time for these sessions, and I apologise for
-any inconvenience this has caused. I am excited to have you as a part of
-our Instructor community.
+I know it is hard to make time for these sessions, and I apologise for any inconvenience this has caused. I am excited to have  you as a part of our Instructor community.
 
-Sincerely,
-
-[Name]
-
-## FAQ
-
-**Help! I’m hosting a teaching demo but I don’t have Host access on Zoom, so can’t enable screen sharing.**
-
-Check your Calendly confirmation email for the Host Key. This key is
-also available in a message in the [Trainers Topicbox channel](https://carpentries.topicbox.com/groups/trainers/T3ec157cc9a3d1833/zoom-host-code). If you have difficulty, you can post in the #trainers channel on Slack.
-
-
-
-
+Sincerely,  
+\[Name\]


### PR DESCRIPTION
Addresses #137 by replacing the entire content of the Instructor Trainer handbook with the content of the shared google doc. 