### PR TITLE
Replace/remove links to CDH

### DIFF
--- a/source/handbooks/lesson_developers.md
+++ b/source/handbooks/lesson_developers.md
@@ -190,13 +190,10 @@ these values where appropriate, creating new topic tags where no
 pre-existing label exists for your lesson.
 
 
-### How to Organise a Lesson Development Sprint
+### [How to Organise a Lesson Development Sprint](/resources/curriculum/lesson-sprint-recommendations.md)
 
-Many Lesson Developers find it helpful to organise a dedicated event to
-make progress and enhance collaboration on their lesson projects. The
-Curriculum Development Handbook includes a set of recommendations for
-[how to organise an effective and inclusive lesson development sprint
-event](https://cdh.carpentries.org/lesson-sprint-recommendations.html).
+Many Lesson Developers find it helpful to organise a dedicated event to make progress and enhance collaboration on their lesson projects. 
+This resource provides a set of recommendations for how to organise an effective and inclusive lesson development sprint event.
 
 ### Promoting Your Project in The Incubator Lesson Spotlight
 
@@ -256,145 +253,11 @@ steps:
    and answer the questions in the issue template to tell the Editors
    about the lesson.
 
-### Piloting a Lesson
+### [Piloting a Lesson](/resources/curriculum/lesson-pilots.md)
 
-Teaching a lesson for the first time is very rewarding, but the
-experience of the Instructors and learners also identifies opportunities
-to address and further clarify parts of the content. This makes early
-lesson teachings, which we refer to as *lesson pilots*, crucial
-milestones in the development of a high-quality lesson. As well as
-teaching new and exciting skills to learners, the additional purpose of
-pilot workshops is to collect information and feedback that can be used
-to polish content and make the lesson more reusable by other Instructors
-(e.g. by recording accurate timings for episodes and exercises,
-expanding Instructor Notes, etc.).
-
-#### Alpha and Beta Pilots
-
-The lesson development process includes pilot workshops at two different
-stages, which we refer to as *alpha* and *beta* pilots. Alpha pilots are
-the first workshops where the lesson is taught, almost always by some or
-all of the original developers of the lesson.
-
-After the feedback from these alpha pilots has been used to improve the
-lesson, it can enter the beta stage, where other Instructors - who did
-not have a major part in the previous development of the lesson - teach
-it and provide feedback.
-
-Information about these pilots, and the requirements for piloting
-official Carpentries lessons, can be found in the `Lesson Life Cycle
-chapter of [The Carpentries Curriculum Development
-Handbook](https://cdh.carpentries.org/the-lesson-life-cycle.html).
-
-#### Information for Lesson Developers
-
-##### Finding Hosts for Beta Pilots
-
-If you are developing a new official Carpentries lesson - a lesson
-developed based on prior agreement with The Carpentries, and is intended
-to become another lesson/curriculum offered in centrally-organised
-workshops - the Curriculum Team will help you find hosts and Instructors
-for pilot workshops.
-
-If you are developing a lesson in The Carpentries Incubator, you can
-recruit pilot hosts by putting out a call via the discuss[ TopicBox
-list](https://carpentries.topicbox.com/groups/discuss), the general
-channel on [The Carpentries Slack
-workspace](https://carpentries.org/connect/), by publishing a post
-on our blog,
-and/or by any other communications channel that you think appropriate
-(e.g. the mailing list of a specific community likely to be interested
-in the lesson topic). You may find this [template blog
-post](https://docs.google.com/document/d/1z8QmxDIiew-p1d8aLzXa0vt0FLUHNtK3oS3tucyrRsI/edit?usp=sharing)
-and/or this [template email
-message](https://docs.google.com/document/d/1hHnm-Ljb_o_rNd9bvQ83ilq40KoGoEfMPTSrFS4QOj8/edit?usp=sharing)
-helpful starting points. If after taking these steps, you need help
-finding hosts to pilot your lesson, or if you have any questions about
-the lesson pilot process for lessons in The Carpentries Incubator, you
-can [contact the Incubator administrator
-team](mailto:incubator@carpentries.org).
-
-##### Collecting Feedback on the Lesson
-
-Feedback from learners will be a valuable source of information about
-and suggestions for how your lesson could be further improved after the
-pilot. The standard Carpentries pre- and post-workshop surveys do not
-support lesson pilots so you will need to create your own surveys to
-send out before/after a pilot workshop. Although surveys for pilot
-workshops will frequently include questions that are specific to the
-particular lesson being piloted, there are some standard feedback
-questions that can be asked after a pilot to assess the design and flow
-of the lesson. This [template post-pilot workshop
-survey](https://docs.google.com/forms/d/1OGCQBotD2nOJkc7KpFZLhFfb3EBcxEDwHz_3p48qz3U/template/preview)
-can be copied and adapted to your lesson, and shared with learners in
-place of the standard post-workshop survey.
-
-It is also important to gather information about the lesson while it is
-being taught. Check the Lesson Life Cycle chapter of[ The Carpentries
-Curriculum Development
-Handbook](https://cdh.carpentries.org/the-lesson-life-cycle.html#field-testing-alpha-stage)
-for a list of things to take note of during the pilot workshop. We
-recommend assigning a specific person or people to keep track of these
-points (e.g. an Instructor or Helper). You may find it helpful to make a
-copy of the [pilot observation notes
-template](https://codimd.carpentries.org/lesson-pilot-observation-notes-template)
-to use during the workshop.
-
-#### Information for Hosts
-
-##### Recruiting Instructors for Beta Pilots
-
-If you are hosting a pilot of a new official Carpentries lesson - a
-lesson developed based on prior agreement with The Carpentries, and
-which is intended to become another lesson/curriculum offered in
-centrally-organised workshops - the Curriculum Team will help you find
-Instructors for pilot workshops.
-
-The Carpentries is also keen to support the development and piloting of
-lessons in The Carpentries Incubator. If you are hosting a pilot of a
-lesson in the Incubator, we ask that you **first** try to find
-Instructors for pilot workshops yourself. Often, hosts are able to
-recruit certified Instructors from their local community with relevant
-knowledge of the lesson topic, but in some cases this will not be
-possible. If you wish to recruit Instructors for a pilot workshop, try
-putting a call out on [local/regional community mailing
-lists](https://carpentries.topicbox.com/groups), any relevant
-channels on [The Carpentries Slack
-workspace](https://carpentries.org/connect/) (the lesson authors may
-be able to direct you to these), and/or by publishing a post on our
-blog.
-Please do not post calls for Instructors to the general or instructors
-channel on Slack, or the discuss and instructors lists on TopicBox. Any
-messages to recruit Instructors will be removed from those channels. If
-after taking these steps, you find that you need help finding
-Instructors for your lesson pilot, you can email the [Incubator
-administrator team](mailto:incubator@carpentries.org) for assistance.
-
-##### Creating a Pilot Workshop Webpage
-
-The Carpentries [workshop webpage
-template](https://github.com/carpentries/workshop-template) supports
-the creation of webpages for pilot workshops. [The Customisation page of
-the template documentation](https://carpentries.github.io/workshop-template/customization/#configuration-file-_configyml)
-has instructions on how to configure the webpage for a pilot workshop.
-
-If you are piloting a new official Carpentries lesson - a lesson
-developed based on prior agreement with The Carpentries, and which is
-intended to become another lesson/curriculum offered in
-centrally-organised workshops - please register your pilot as a
-{{'[Self-Organised Workshop]({}/forms/workshop/)'.format(amy_link)}}. If you
-do not find the lesson/curriculum being piloted listed as one of the
-choices on that form, please contact [The Carpentries Core
-Team](mailto:team@carpentries.org).
-
-For workshops teaching lessons in The Carpentries Incubator, you should
-create a workshop webpage but should not submit the workshop details to
-The Carpentries team via the form linked above. Instead, if you want to
-tell the community about your event you can do so by filling in the form
-under *Workshops* on [The Incubator
-homepage](https://carpentries-incubator.org/). Workshops submitted
-there will be processed by the Curriculum Team and will be listed in the
-table on that page.
+Teaching a lesson for the first time is very rewarding, but the experience of the Instructors and learners also identifies opportunities to address and further clarify parts of the content. 
+This makes early lesson teachings, which we refer to as *lesson pilots*, crucial milestones in the development of a high-quality lesson. 
+This resource provides more information about how to test a new lesson in workshops, how these pilot workshops align with [the Lesson Life Cycle](/resources/curriculum/lesson-life-cycle.md), and guidance on logistics, gathering relevant feedback, etc.
 
 ## Resources
 
@@ -407,20 +270,6 @@ Workbench so that Lesson Developers can edit and preview their lessons
 on their own computer, how to initialise a new lesson and use the
 various elements of the lesson template, and how to keep up to date with
 the latest changes to the infrastructure.
-
-### [Curriculum Development Handbook](https://cdh.carpentries.org/)
-
-A guide to the lesson design process recommended by The Carpentries. The
-CDH provides details of the curriculum structure used by our Lesson
-Programs, the vocabulary we use to describe the [life cycle stages of
-the
-lesson](https://carpentries.github.io/lesson-development-training/19-operations.html#the-lesson-life-cycle),
-and the steps we encourage Lesson Developers to take through those
-stages. **Note: the Curriculum Team is in the process of replacing the
-content of the CDH with this handbook and the [Collaborative Lesson
-Development Training
-curriculum](https://carpentries.github.io/lesson-development-training/),
-and it is no longer actively updated.
 
 ### [Collaborative Lesson Development Training Curriculum](https://carpentries.github.io/lesson-development-training/)
 

--- a/source/handbooks/lesson_developers.md
+++ b/source/handbooks/lesson_developers.md
@@ -135,13 +135,6 @@ To join one or more Carpentries mailing lists, you will need to [create a login 
 
 ## Step-by-Step Guides
 
-### Adapting Existing Lessons for The Carpentries
-
-Lessons must use The Carpentries template and infrastructure to be
-included in the Incubator or Lab. The Curriculum Development Handbook
-includes a guide for adapting existing lessons to use [The Carpentries
-lesson template](https://cdh.carpentries.org/adapting-existing-lessons-for-the-carpentries.html).
-
 ### Using Issue Labels to Promote Collaboration
 
 GitHub allows the maintainers of a repository to add contextual

--- a/source/handbooks/maintainers.md
+++ b/source/handbooks/maintainers.md
@@ -258,18 +258,11 @@ A collection of recommendations for community members who want to organise event
 
 ### {{'[Lesson Release Process]({}/resources/curriculum/lesson-release.html)'.format(handbook_url)}}
 
-### [Curriculum Development Handbook](https://cdh.carpentries.org/)
 
-A guide to the lesson design process recommended by The Carpentries. The
-CDH provides details of the curriculum structure used in our Lesson
-Programs, the vocabulary we use to describe the [life cycle stages of
-the lesson](https://carpentries.github.io/lesson-development-training/19-operations.html#the-lesson-life-cycle),
-and the steps we encourage Lesson Maintainers to take through those
-stages. **Note: the Curriculum Team is in the process of replacing the
-content of the CDH with this handbook and
-the [Collaborative Lesson
-Development Training curriculum](https://carpentries.github.io/lesson-development-training/),
-and it is no longer actively updated.**
+### [Lesson Developer Handbook](/handbooks/lesson_developers.md)
+
+The handbook for community members developing new lessons includes information, guidance, and further resources that may also be interesting to Mainatiners.
+
 
 ### [Collaborative Lesson Development Training Curriculum](https://carpentries.github.io/lesson-development-training/)
 

--- a/source/resources/curriculum/lesson-pilots.md
+++ b/source/resources/curriculum/lesson-pilots.md
@@ -17,16 +17,15 @@ After the feedback from these alpha pilots has been used to improve the lesson, 
 who did not have a major part in the previous development of the lesson - 
 teach it and provide feedback.
 
-For more information about these pilots, and the requirements for piloting official Carpentries lessons, see [the Lesson Life Cycle chapter of The Carpentries Curriculum Development Handbook](https://cdh.carpentries.org/the-lesson-life-cycle.html).
+The [Lesson Life Cycle page](/resources/curriculum/lesson-life-cycle.md) includes more information about how pilot workshops fit into the iterative development process of a new lesson/curriculum.
+The [How We Operate episode](https://carpentries.github.io/lesson-development-training/operations.html#pilot-workshops) of Collaborative Lesson Development Training includes more discussion of pilot workshops, how to prepare to teach them, and the information it can be helpful to collect during the event.
 
 ## Information for Lesson Developers
 
 ### Finding Hosts for Beta Pilots
 
 If you are developing a new official Carpentries lesson -
-a lesson developed based on prior agreement with The Carpentries,
-and which is intended to become another lesson/curriculum offered
-in centrally-organised workshops -
+a lesson developed based on prior agreement with The Carpentries, and which is intended to become another lesson/curriculum offered in centrally-organised workshops -
 [the Curriculum Team](mailto:team@carpentries.org) will help you find hosts and Instructors for pilot workshops.
 
 If you are developing a lesson in The Carpentries Incubator, you can recruit pilot hosts by putting out a call via:
@@ -47,7 +46,7 @@ Although surveys for pilot workshops will frequently include questions that are 
 This [template post-pilot workshop survey](https://docs.google.com/forms/d/1OGCQBotD2nOJkc7KpFZLhFfb3EBcxEDwHz_3p48qz3U/template/preview) can be copied and adapted to suit the needs of your lesson, and shared with learners in place of the standard post-workshop survey.
 
 It is also important to gather information about the lesson while it is being taught.
-Check [the Lesson Life Cycle chapter of The Carpentries Curriculum Development Handbook](https://cdh.carpentries.org/the-lesson-life-cycle.html#field-testing-alpha-stage) for a list of things to take note of during the pilot workshop.
+Check the [How We Operate episode](https://carpentries.github.io/lesson-development-training/operations.html#pilot-workshops) of Collaborative Lesson Development Training for a list of things to take note of during the pilot workshop.
 We recommend assigning a specific person or people to keep track of these points (e.g. an instructor or helper).
 You may find it helpful to make a copy of [the pilot observation notes template](https://codimd.carpentries.org/lesson-pilot-observation-notes-template) to use during the workshop.
 


### PR DESCRIPTION
Closes #249 by removing all links to the Curriculum Development Handbook.