### PR TITLE
Update 404 page

### DIFF
--- a/source/404.md
+++ b/source/404.md
@@ -1,5 +1,7 @@
 # Page Not Found
 
-Oops! The page you’re looking for doesn’t exist.
+## This page may have moved.
 
-If you think this was a mistake, please let us know.
+Please select a page from the side menu or contact team@carpentries.org if you need additional help.
+
+You may also visit our main website at https://carpentries.org.

--- a/source/conf.py
+++ b/source/conf.py
@@ -42,10 +42,6 @@ extensions = [
     'notfound.extension'
 ]
 
-notfound_context = {
-    'body': '<h1>This page may have moved.</h1> <p>Please select a page from the side menu or contact team@carpentries.org if you need additional help.</p>',
-}
-
 notfound_urls_prefix = ""
 
 myst_enable_extensions = ["colon_fence",


### PR DESCRIPTION
#259 set up the `sphinx-notfound-page` extension and put the 404 page body text in `conf.py`.  It seems having a 404 file overrides the content of the text in conf.  A stand alone 404 page is easier to maintain, so this PR tries removing the definition in conf and only having a 404 file. 
