### PR TITLE
add license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,70 @@
+# License
+
+
+## Website content
+
+Unless specified otherwise, the text content of this website is
+licensed [Creative Commons Attribution 4.0 International
+License](https://creativecommons.org/licenses/by/4.0/). This is a human-readable
+summary of (and not a substitute for) [the
+license](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+Images on this website are under copyright of the original creator unless 
+otherwise specified.
+
+### You are free to:
+
+- **Share** — copy and redistribute the material in any medium or format
+- **Adapt** — remix, transform, and build upon the material for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+### Under the following terms:
+
+- **Attribution** — You must give appropriate credit, provide a link to the
+  license, and indicate if changes were made. You may do so in any reasonable
+  manner, but not in any way that suggests the licensor endorses you or your
+  use.
+- **No additional restrictions** — You may not apply legal terms or
+  technological measures that legally restrict others from doing anything the
+  license permits.
+
+### Notices:
+
+You do not have to comply with the license for elements of the material in the 
+public domain or where your use is permitted by an applicable exception or limitation.
+
+No warranties are given. The license may not give you all of the permissions necessary 
+for your intended use. For example, other rights such as publicity, privacy, or moral 
+rights may limit how you use the material.
+
+
+## Copyright
+
+Copyright (c) 2018-2024 The Carpentries
+
+### The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+## Trademarks
+
+"Software Carpentry", "Data Carpentry", and "The Carpentries" and their 
+respective logos are registered trademarks of The Carpentries Inc. 501(c)3.

--- a/source/_templates/footer_end.html
+++ b/source/_templates/footer_end.html
@@ -9,6 +9,7 @@
       <br/>
     {% endif %}
   </p>
+  <p><a href="https://github.com/carpentries/handbook-beta/blob/main/LICENSE.md">LICENSE</a></p>
 {% endif %}
 
 <p class="theme-version">


### PR DESCRIPTION
Copies license directly from the [website](https://carpentries.org/license/).  